### PR TITLE
Remove STAGE tag

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 root = true
 
 [*]
-
 indent_style = space
 indent_size = 2
 end_of_line = lf

--- a/__tests__/fixtures/vpc_multiple_az_multiple_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_multiple_natgw_no_db.json
@@ -9,19 +9,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP1",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP1", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -49,19 +42,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP2",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP2", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet2"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -85,10 +71,6 @@
       "AvailabilityZone": "us-east-1a",
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -117,10 +99,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -169,10 +147,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -200,10 +174,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -252,10 +222,6 @@
       "CidrBlock": "10.0.16.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -283,10 +249,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -335,10 +297,6 @@
       "CidrBlock": "10.0.24.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -366,10 +324,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -418,10 +372,6 @@
       "CidrBlock": "10.0.32.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -449,10 +399,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -501,10 +447,6 @@
       "CidrBlock": "10.0.40.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -532,10 +474,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_multiple_az_natgw_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_natgw_db.json
@@ -9,19 +9,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP1",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP1", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -49,19 +42,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP2",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP2", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet2"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -85,10 +71,6 @@
       "AvailabilityZone": "us-east-1a",
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -117,10 +99,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -169,10 +147,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -200,10 +174,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -252,10 +222,6 @@
       "CidrBlock": "10.0.12.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -283,10 +249,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -323,10 +285,6 @@
       "CidrBlock": "10.0.16.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -354,10 +312,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -406,10 +360,6 @@
       "CidrBlock": "10.0.24.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -437,10 +387,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -489,10 +435,6 @@
       "CidrBlock": "10.0.28.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -520,10 +462,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_multiple_az_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_natgw_no_db.json
@@ -9,19 +9,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP1",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP1", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -49,19 +42,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP2",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP2", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet2"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -85,10 +71,6 @@
       "AvailabilityZone": "us-east-1a",
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -117,10 +99,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -169,10 +147,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -200,10 +174,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -252,10 +222,6 @@
       "CidrBlock": "10.0.16.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -283,10 +249,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -335,10 +297,6 @@
       "CidrBlock": "10.0.24.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -366,10 +324,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_multiple_az_no_natgw_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_no_natgw_db.json
@@ -6,10 +6,6 @@
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -37,10 +33,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -89,10 +81,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -120,10 +108,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -172,10 +156,6 @@
       "CidrBlock": "10.0.12.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -203,10 +183,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -243,10 +219,6 @@
       "CidrBlock": "10.0.16.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -274,10 +246,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -326,10 +294,6 @@
       "CidrBlock": "10.0.24.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -357,10 +321,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -409,10 +369,6 @@
       "CidrBlock": "10.0.28.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -440,10 +396,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_multiple_az_no_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_no_natgw_no_db.json
@@ -6,10 +6,6 @@
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -37,10 +33,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -89,10 +81,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -120,10 +108,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -172,10 +156,6 @@
       "CidrBlock": "10.0.16.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -203,10 +183,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -255,10 +231,6 @@
       "CidrBlock": "10.0.24.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -286,10 +258,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_multiple_az_single_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_single_natgw_no_db.json
@@ -9,19 +9,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP1",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP1", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -45,10 +38,6 @@
       "AvailabilityZone": "us-east-1a",
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -77,10 +66,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -129,10 +114,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -160,10 +141,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -212,10 +189,6 @@
       "CidrBlock": "10.0.16.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -243,10 +216,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -295,10 +264,6 @@
       "CidrBlock": "10.0.24.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -326,10 +291,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_single_az_natgw_db.json
+++ b/__tests__/fixtures/vpc_single_az_natgw_db.json
@@ -9,19 +9,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP1",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP1", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -45,10 +38,6 @@
       "AvailabilityZone": "us-east-1a",
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -77,10 +66,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -129,10 +114,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -160,10 +141,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -212,10 +189,6 @@
       "CidrBlock": "10.0.12.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -243,10 +216,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_single_az_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_single_az_natgw_no_db.json
@@ -9,19 +9,12 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": [
-          "EIP1",
-          "AllocationId"
-        ]
+        "Fn::GetAtt": ["EIP1", "AllocationId"]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -45,10 +38,6 @@
       "AvailabilityZone": "us-east-1a",
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -77,10 +66,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -129,10 +114,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -160,10 +141,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_single_az_no_natgw_db.json
+++ b/__tests__/fixtures/vpc_single_az_no_natgw_db.json
@@ -6,10 +6,6 @@
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -37,10 +33,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -89,10 +81,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -120,10 +108,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -172,10 +156,6 @@
       "CidrBlock": "10.0.12.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -203,10 +183,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_single_az_no_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_single_az_no_natgw_no_db.json
@@ -6,10 +6,6 @@
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -37,10 +33,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -89,10 +81,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -120,10 +108,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/fixtures/vpc_single_az_no_natgw_no_db_nacl.json
+++ b/__tests__/fixtures/vpc_single_az_no_natgw_no_db_nacl.json
@@ -6,10 +6,6 @@
       "CidrBlock": "10.0.0.0/21",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -37,10 +33,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -89,10 +81,6 @@
       "CidrBlock": "10.0.8.0/22",
       "Tags": [
         {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
-        {
           "Key": "Name",
           "Value": {
             "Fn::Join": [
@@ -120,10 +108,6 @@
         "Ref": "VPC"
       },
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -169,10 +153,6 @@
     "Type": "AWS::EC2::NetworkAcl",
     "Properties": {
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {
@@ -234,10 +214,6 @@
     "Type": "AWS::EC2::NetworkAcl",
     "Properties": {
       "Tags": [
-        {
-          "Key": "STAGE",
-          "Value": "dev"
-        },
         {
           "Key": "Name",
           "Value": {

--- a/__tests__/flow_logs.test.js
+++ b/__tests__/flow_logs.test.js
@@ -111,10 +111,6 @@ describe('flow_logs', () => {
             },
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [' ', [{ Ref: 'AWS::StackName' }, 'Logs']],
@@ -124,7 +120,7 @@ describe('flow_logs', () => {
           },
         },
       };
-      const actual = buildLogBucket('dev');
+      const actual = buildLogBucket();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -217,7 +217,7 @@ describe('ServerlessVpcPlugin', () => {
 
   describe('#buildAvailabilityZones', () => {
     it('builds no AZs without options', () => {
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16');
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16');
       expect(actual).toEqual({});
       expect.assertions(1);
     });
@@ -225,7 +225,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds a single AZ with a NAT Gateway and DBSubnet', () => {
       const expected = Object.assign({}, vpcSingleAZNatGWDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a'],
         numNatGateway: 1,
         createDbSubnet: true,
@@ -237,7 +237,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds a single AZ without a NAT Gateway and DBSubnet', () => {
       const expected = Object.assign({}, vpcSingleAZNoGatGWDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a'],
         numNatGateway: 0,
         createDbSubnet: true,
@@ -249,7 +249,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds a single AZ with a NAT Gateway and no DBSubnet', () => {
       const expected = Object.assign({}, vpcSingleAZNatGWNoDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a'],
         numNatGateway: 1,
         createDbSubnet: false,
@@ -261,7 +261,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds a single AZ without a NAT Gateway and no DBSubnet', () => {
       const expected = Object.assign({}, vpcSingleAZNoGatGWNoDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a'],
         numNatGateway: 0,
         createDbSubnet: false,
@@ -273,7 +273,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds multiple AZs with a NAT Gateway and DBSubnet', () => {
       const expected = Object.assign({}, vpcMultipleAZNatGWDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a', 'us-east-1b'],
         numNatGateway: 2,
         createDbSubnet: true,
@@ -285,7 +285,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds multiple AZs without a NAT Gateway and DBSubnet', () => {
       const expected = Object.assign({}, vpcMultipleAZNoNatGWDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a', 'us-east-1b'],
         numNatGateway: 0,
         createDbSubnet: true,
@@ -297,7 +297,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds multiple AZs with a NAT Gateway and no DBSubnet', () => {
       const expected = Object.assign({}, vpcMultipleAZNatGWNoDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a', 'us-east-1b'],
         numNatGateway: 2,
         createDbSubnet: false,
@@ -309,7 +309,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds multiple AZs without a NAT Gateway and no DBSubnet', () => {
       const expected = Object.assign({}, vpcMultipleAZNoNatGWNoDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a', 'us-east-1b'],
         numNatGateway: 0,
         createDbSubnet: false,
@@ -321,7 +321,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds multiple AZs with a single NAT Gateway and no DBSubnet', () => {
       const expected = Object.assign({}, vpcMultipleAZSingleNatGWNoDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a', 'us-east-1b'],
         numNatGateway: 1,
         createDbSubnet: false,
@@ -333,7 +333,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds multiple AZs with a multple NAT Gateways and no DBSubnet', () => {
       const expected = Object.assign({}, vpcMultipleAZMultipleNatGWNoDB);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a', 'us-east-1b', 'us-east-1c'],
         numNatGateway: 2,
         createDbSubnet: false,
@@ -345,7 +345,7 @@ describe('ServerlessVpcPlugin', () => {
     it('builds a single AZ without a NAT Gateway and no DBSubnet and NACL', () => {
       const expected = Object.assign({}, vpcSingleAZNoNatGWNoDBNACL);
 
-      const actual = ServerlessVpcPlugin.buildAvailabilityZones('dev', '10.0.0.0/16', {
+      const actual = ServerlessVpcPlugin.buildAvailabilityZones('10.0.0.0/16', {
         zones: ['us-east-1a'],
         numNatGateway: 0,
         createDbSubnet: false,

--- a/__tests__/nacl.test.js
+++ b/__tests__/nacl.test.js
@@ -16,10 +16,6 @@ describe('nacl', () => {
           Properties: {
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [
@@ -40,7 +36,7 @@ describe('nacl', () => {
           },
         },
       };
-      const actual = buildNetworkAcl('dev', 'App');
+      const actual = buildNetworkAcl('App');
       expect(actual).toEqual(expected);
     });
   });
@@ -116,10 +112,6 @@ describe('nacl', () => {
           Type: 'AWS::EC2::NetworkAcl',
           Properties: {
             Tags: [
-              {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
               {
                 Key: 'Name',
                 Value: {
@@ -200,7 +192,7 @@ describe('nacl', () => {
           },
         },
       };
-      const actual = buildPublicNetworkAcl('dev', 3);
+      const actual = buildPublicNetworkAcl(3);
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -213,10 +205,6 @@ describe('nacl', () => {
           Type: 'AWS::EC2::NetworkAcl',
           Properties: {
             Tags: [
-              {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
               {
                 Key: 'Name',
                 Value: {
@@ -297,7 +285,7 @@ describe('nacl', () => {
           },
         },
       };
-      const actual = buildAppNetworkAcl('dev', 3);
+      const actual = buildAppNetworkAcl(3);
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -310,10 +298,6 @@ describe('nacl', () => {
           Type: 'AWS::EC2::NetworkAcl',
           Properties: {
             Tags: [
-              {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
               {
                 Key: 'Name',
                 Value: {
@@ -447,7 +431,7 @@ describe('nacl', () => {
         },
       };
       const appSubnets = ['10.0.0.0/21', '10.0.16.0/21', '10.0.32.0/21'];
-      const actual = buildDBNetworkAcl('dev', appSubnets);
+      const actual = buildDBNetworkAcl(appSubnets);
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/__tests__/natgw.test.js
+++ b/__tests__/natgw.test.js
@@ -31,10 +31,6 @@ describe('natgw', () => {
             },
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [
@@ -52,7 +48,7 @@ describe('natgw', () => {
           },
         },
       };
-      const actual = buildNatGateway('dev', 1, 'us-east-1a');
+      const actual = buildNatGateway(1, 'us-east-1a');
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/__tests__/subnet_groups.test.js
+++ b/__tests__/subnet_groups.test.js
@@ -32,16 +32,10 @@ describe('subnet_groups', () => {
                 Ref: 'DBSubnet2',
               },
             ],
-            Tags: [
-              {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-            ],
           },
         },
       };
-      const actual = buildRDSSubnetGroup('dev', { numZones: 2 });
+      const actual = buildRDSSubnetGroup({ numZones: 2 });
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -65,16 +59,10 @@ describe('subnet_groups', () => {
                 Ref: 'DBSubnet2',
               },
             ],
-            Tags: [
-              {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-            ],
           },
         },
       };
-      const actual = buildRDSSubnetGroup('dev', {
+      const actual = buildRDSSubnetGroup({
         name: 'MyRDSSubnetGroup',
         numZones: 2,
       });
@@ -171,16 +159,10 @@ describe('subnet_groups', () => {
                 Ref: 'DBSubnet2',
               },
             ],
-            Tags: [
-              {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-            ],
           },
         },
       };
-      const actual = buildRedshiftSubnetGroup('dev', { numZones: 2 });
+      const actual = buildRedshiftSubnetGroup({ numZones: 2 });
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -201,16 +183,10 @@ describe('subnet_groups', () => {
                 Ref: 'DBSubnet2',
               },
             ],
-            Tags: [
-              {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-            ],
           },
         },
       };
-      const actual = buildRedshiftSubnetGroup('dev', {
+      const actual = buildRedshiftSubnetGroup({
         name: 'MyRedshiftSubnetGroup',
         numZones: 2,
       });

--- a/__tests__/vpc.test.js
+++ b/__tests__/vpc.test.js
@@ -22,10 +22,6 @@ describe('vpc', () => {
             InstanceTenancy: 'default',
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   Ref: 'AWS::StackName',
@@ -36,7 +32,7 @@ describe('vpc', () => {
         },
       };
 
-      const actual = buildVpc('dev');
+      const actual = buildVpc();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -52,10 +48,6 @@ describe('vpc', () => {
             InstanceTenancy: 'default',
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   Ref: 'AWS::StackName',
@@ -66,7 +58,7 @@ describe('vpc', () => {
         },
       };
 
-      const actual = buildVpc('dev', {
+      const actual = buildVpc({
         name: 'MyVpc',
         cidrBlock: '192.168.0.0/16',
       });
@@ -83,10 +75,6 @@ describe('vpc', () => {
           Properties: {
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   Ref: 'AWS::StackName',
@@ -97,7 +85,7 @@ describe('vpc', () => {
         },
       };
 
-      const actual = buildInternetGateway('dev');
+      const actual = buildInternetGateway();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -109,10 +97,6 @@ describe('vpc', () => {
           Properties: {
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   Ref: 'AWS::StackName',
@@ -123,7 +107,7 @@ describe('vpc', () => {
         },
       };
 
-      const actual = buildInternetGateway('dev', { name: 'MyInternetGateway' });
+      const actual = buildInternetGateway({ name: 'MyInternetGateway' });
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -184,10 +168,6 @@ describe('vpc', () => {
             CidrBlock: '10.0.0.0/22',
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [
@@ -209,7 +189,7 @@ describe('vpc', () => {
           },
         },
       };
-      const actual = buildSubnet('dev', 'App', 1, 'us-east-1a', '10.0.0.0/22');
+      const actual = buildSubnet('App', 1, 'us-east-1a', '10.0.0.0/22');
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -226,10 +206,6 @@ describe('vpc', () => {
             },
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [
@@ -248,7 +224,7 @@ describe('vpc', () => {
           },
         },
       };
-      const actual = buildRouteTable('dev', 'App', 1, 'us-east-1a');
+      const actual = buildRouteTable('App', 1, 'us-east-1a');
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -340,10 +316,6 @@ describe('vpc', () => {
             },
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [
@@ -361,7 +333,7 @@ describe('vpc', () => {
           },
         },
       };
-      const actual = buildLambdaSecurityGroup('dev');
+      const actual = buildLambdaSecurityGroup();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -377,10 +349,6 @@ describe('vpc', () => {
             },
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [
@@ -398,7 +366,7 @@ describe('vpc', () => {
           },
         },
       };
-      const actual = buildLambdaSecurityGroup('dev', {
+      const actual = buildLambdaSecurityGroup({
         name: 'MyLambdaExecutionSecurityGroup',
       });
       expect(actual).toEqual(expected);

--- a/__tests__/vpce.test.js
+++ b/__tests__/vpce.test.js
@@ -305,10 +305,6 @@ describe('vpce', () => {
             ],
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [
@@ -326,7 +322,7 @@ describe('vpce', () => {
           },
         },
       };
-      const actual = buildLambdaVPCEndpointSecurityGroup('dev');
+      const actual = buildLambdaVPCEndpointSecurityGroup();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -352,10 +348,6 @@ describe('vpce', () => {
             ],
             Tags: [
               {
-                Key: 'STAGE',
-                Value: 'dev',
-              },
-              {
                 Key: 'Name',
                 Value: {
                   'Fn::Join': [
@@ -373,7 +365,7 @@ describe('vpce', () => {
           },
         },
       };
-      const actual = buildLambdaVPCEndpointSecurityGroup('dev', {
+      const actual = buildLambdaVPCEndpointSecurityGroup({
         name: 'MyLambdaEndpointSecurityGroup',
       });
       expect(actual).toEqual(expected);

--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "aws-sdk": "2.290.0",
     "serverless": "1.39.1",
-    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#master"
+    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#jp-remove-stage-tags"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "aws-sdk": "2.290.0",
     "serverless": "1.39.1",
-    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#jp-remove-stage-tags"
+    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#master"
   }
 }

--- a/example/resources/s3_cf.yml
+++ b/example/resources/s3_cf.yml
@@ -13,9 +13,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-      Tags:
-        - Key: STAGE
-          Value: ${self:provider.stage}
 
   TestBucketPolicy:
     Type: 'AWS::S3::BucketPolicy'
@@ -35,13 +32,13 @@ Resources:
                   - Arn
             Resource:
               - 'Fn::GetAtt':
-                - TestBucket
-                - Arn
+                  - TestBucket
+                  - Arn
               - 'Fn::Join':
-                - ''
-                - - 'arn:aws:s3:::'
-                  - Ref: TestBucket
-                  - '/*'
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - Ref: TestBucket
+                    - '/*'
             Condition:
               StringEquals:
                 'aws:sourceVpce':

--- a/src/flow_logs.js
+++ b/src/flow_logs.js
@@ -1,10 +1,9 @@
 /**
  * Build an S3 bucket for logging
  *
- * @param {String} stage
  * @return {Object}
  */
-function buildLogBucket(stage) {
+function buildLogBucket() {
   return {
     LogBucket: {
       Type: 'AWS::S3::Bucket',
@@ -27,10 +26,6 @@ function buildLogBucket(stage) {
           RestrictPublicBuckets: true,
         },
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {

--- a/src/index.js
+++ b/src/index.js
@@ -183,11 +183,11 @@ class ServerlessVpcPlugin {
         },
       ],
     };
-
-    const data = await this.provider.request('EC2', 'describeAvailabilityZones', params).promise();
-    return data.AvailabilityZones.filter(z => z.State === 'available')
-      .map(z => z.ZoneName)
-      .sort();
+    return this.provider.request('EC2', 'describeAvailabilityZones', params).then(data =>
+      data.AvailabilityZones.filter(z => z.State === 'available')
+        .map(z => z.ZoneName)
+        .sort(),
+    );
   }
 
   /**
@@ -199,10 +199,9 @@ class ServerlessVpcPlugin {
     const params = {
       MaxResults: 1000,
     };
-    const data = await this.provider
+    return this.provider
       .request('EC2', 'describeVpcEndpointServices', params)
-      .promise();
-    return data.ServiceNames.sort();
+      .then(data => data.ServiceNames.sort());
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,6 @@ class ServerlessVpcPlugin {
     }
 
     const region = this.provider.getRegion();
-    const stage = this.provider.getStage();
 
     if (zones.length < 1) {
       this.serverless.cli.log(`Discovering available zones in ${region}...`);
@@ -116,16 +115,16 @@ class ServerlessVpcPlugin {
 
     Object.assign(
       this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-      buildVpc(stage, { cidrBlock }),
-      buildInternetGateway(stage),
+      buildVpc({ cidrBlock }),
+      buildInternetGateway(),
       buildInternetGatewayAttachment(),
-      ServerlessVpcPlugin.buildAvailabilityZones(stage, cidrBlock, {
+      ServerlessVpcPlugin.buildAvailabilityZones(cidrBlock, {
         zones,
         numNatGateway: createNatGateway,
         createDbSubnet,
         createNetworkAcl,
       }),
-      buildLambdaSecurityGroup(stage),
+      buildLambdaSecurityGroup(),
     );
 
     if (services.length > 0) {
@@ -140,7 +139,7 @@ class ServerlessVpcPlugin {
       Object.assign(
         this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
         buildEndpointServices({ services, numZones }),
-        buildLambdaVPCEndpointSecurityGroup(stage),
+        buildLambdaVPCEndpointSecurityGroup(),
       );
     }
 
@@ -150,8 +149,8 @@ class ServerlessVpcPlugin {
       } else {
         Object.assign(
           this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-          buildRDSSubnetGroup(stage, { numZones }),
-          buildRedshiftSubnetGroup(stage, { numZones }),
+          buildRDSSubnetGroup({ numZones }),
+          buildRedshiftSubnetGroup({ numZones }),
           buildElastiCacheSubnetGroup({ numZones }),
           buildDAXSubnetGroup({ numZones }),
         );
@@ -162,7 +161,7 @@ class ServerlessVpcPlugin {
       this.serverless.cli.log('Enabling VPC Flow Logs to S3');
       Object.assign(
         this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        buildLogBucket(stage),
+        buildLogBucket(),
         buildLogBucketPolicy(),
         buildVpcFlowLogs(),
       );
@@ -184,11 +183,11 @@ class ServerlessVpcPlugin {
         },
       ],
     };
-    return this.provider.request('EC2', 'describeAvailabilityZones', params).then(data =>
-      data.AvailabilityZones.filter(z => z.State === 'available')
-        .map(z => z.ZoneName)
-        .sort(),
-    );
+
+    const data = await this.provider.request('EC2', 'describeAvailabilityZones', params).promise();
+    return data.AvailabilityZones.filter(z => z.State === 'available')
+      .map(z => z.ZoneName)
+      .sort();
   }
 
   /**
@@ -200,9 +199,10 @@ class ServerlessVpcPlugin {
     const params = {
       MaxResults: 1000,
     };
-    return this.provider
+    const data = await this.provider
       .request('EC2', 'describeVpcEndpointServices', params)
-      .then(data => data.ServiceNames.sort());
+      .promise();
+    return data.ServiceNames.sort();
   }
 
   /**
@@ -303,7 +303,6 @@ class ServerlessVpcPlugin {
    * 3.) Split the second /21 subnet into two /22 subnets: one Public subnet (for load balancers),
    *     and one for databases (RDS, ElastiCache, and Redshift)
    *
-   * @param {String} stage Serverless Stage
    * @param {String} cidrBlock VPC CIDR Block
    * @param {Array} zones Array of availability zones
    * @param {Number} numNatGateway Number of NAT gateways (and EIPs) to provision
@@ -312,7 +311,6 @@ class ServerlessVpcPlugin {
    * @return {Object}
    */
   static buildAvailabilityZones(
-    stage,
     cidrBlock,
     { zones = [], numNatGateway = 0, createDbSubnet = true, createNetworkAcl = false } = {},
   ) {
@@ -328,11 +326,7 @@ class ServerlessVpcPlugin {
 
     if (numNatGateway > 0) {
       for (let index = 0; index < numNatGateway; index += 1) {
-        Object.assign(
-          resources,
-          buildEIP(index + 1),
-          buildNatGateway(stage, index + 1, zones[index]),
-        );
+        Object.assign(resources, buildEIP(index + 1), buildNatGateway(index + 1, zones[index]));
       }
     }
 
@@ -350,14 +344,14 @@ class ServerlessVpcPlugin {
         resources,
 
         // App Subnet
-        buildSubnet(stage, APP_SUBNET, position, zone, subnets.get(zone).get(APP_SUBNET)),
-        buildRouteTable(stage, APP_SUBNET, position, zone),
+        buildSubnet(APP_SUBNET, position, zone, subnets.get(zone).get(APP_SUBNET)),
+        buildRouteTable(APP_SUBNET, position, zone),
         buildRouteTableAssociation(APP_SUBNET, position),
         buildRoute(APP_SUBNET, position, params),
 
         // Public Subnet
-        buildSubnet(stage, PUBLIC_SUBNET, position, zone, subnets.get(zone).get(PUBLIC_SUBNET)),
-        buildRouteTable(stage, PUBLIC_SUBNET, position, zone),
+        buildSubnet(PUBLIC_SUBNET, position, zone, subnets.get(zone).get(PUBLIC_SUBNET)),
+        buildRouteTable(PUBLIC_SUBNET, position, zone),
         buildRouteTableAssociation(PUBLIC_SUBNET, position),
         buildRoute(PUBLIC_SUBNET, position, {
           GatewayId: 'InternetGateway',
@@ -368,8 +362,8 @@ class ServerlessVpcPlugin {
         // DB Subnet
         Object.assign(
           resources,
-          buildSubnet(stage, DB_SUBNET, position, zone, subnets.get(zone).get(DB_SUBNET)),
-          buildRouteTable(stage, DB_SUBNET, position, zone),
+          buildSubnet(DB_SUBNET, position, zone, subnets.get(zone).get(DB_SUBNET)),
+          buildRouteTable(DB_SUBNET, position, zone),
           buildRouteTableAssociation(DB_SUBNET, position),
         );
       }
@@ -379,11 +373,11 @@ class ServerlessVpcPlugin {
       // Add Network ACLs
       Object.assign(
         resources,
-        buildPublicNetworkAcl(stage, zones.length),
-        buildAppNetworkAcl(stage, zones.length),
+        buildPublicNetworkAcl(zones.length),
+        buildAppNetworkAcl(zones.length),
       );
       if (createDbSubnet) {
-        Object.assign(resources, buildDBNetworkAcl(stage, subnets.get(APP_SUBNET)));
+        Object.assign(resources, buildDBNetworkAcl(subnets.get(APP_SUBNET)));
       }
     }
 

--- a/src/nacl.js
+++ b/src/nacl.js
@@ -3,11 +3,10 @@ const { APP_SUBNET, PUBLIC_SUBNET, DB_SUBNET } = require('./constants');
 /**
  * Build a Network Access Control List (ACL)
  *
- * @param {String} stage
  * @param {String} name
  * @return {Object}
  */
-function buildNetworkAcl(stage, name) {
+function buildNetworkAcl(name) {
   const cfName = `${name}NetworkAcl`;
 
   return {
@@ -15,10 +14,6 @@ function buildNetworkAcl(stage, name) {
       Type: 'AWS::EC2::NetworkAcl',
       Properties: {
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {
@@ -100,10 +95,9 @@ function buildNetworkAclAssociation(name, position) {
 /**
  * Build the Public Network ACL
  *
- * @param {String} stage
  * @param {Number} numZones
  */
-function buildPublicNetworkAcl(stage, numZones = 0) {
+function buildPublicNetworkAcl(numZones = 0) {
   if (numZones < 1) {
     return {};
   }
@@ -112,7 +106,7 @@ function buildPublicNetworkAcl(stage, numZones = 0) {
 
   Object.assign(
     resources,
-    buildNetworkAcl(stage, PUBLIC_SUBNET),
+    buildNetworkAcl(PUBLIC_SUBNET),
     buildNetworkAclEntry(`${PUBLIC_SUBNET}NetworkAcl`, '0.0.0.0/0'),
     buildNetworkAclEntry(`${PUBLIC_SUBNET}NetworkAcl`, '0.0.0.0/0', {
       Egress: true,
@@ -129,10 +123,9 @@ function buildPublicNetworkAcl(stage, numZones = 0) {
 /**
  * Build the Application Network ACL
  *
- * @param {String} stage
  * @param {Number} numZones
  */
-function buildAppNetworkAcl(stage, numZones = 0) {
+function buildAppNetworkAcl(numZones = 0) {
   if (numZones < 1) {
     return {};
   }
@@ -141,7 +134,7 @@ function buildAppNetworkAcl(stage, numZones = 0) {
 
   Object.assign(
     resources,
-    buildNetworkAcl(stage, APP_SUBNET),
+    buildNetworkAcl(APP_SUBNET),
     buildNetworkAclEntry(`${APP_SUBNET}NetworkAcl`, '0.0.0.0/0'),
     buildNetworkAclEntry(`${APP_SUBNET}NetworkAcl`, '0.0.0.0/0', {
       Egress: true,
@@ -158,15 +151,14 @@ function buildAppNetworkAcl(stage, numZones = 0) {
 /**
  * Build the Database Network ACL
  *
- * @param {String} stage
  * @param {Array} appSubnets
  */
-function buildDBNetworkAcl(stage, appSubnets = []) {
+function buildDBNetworkAcl(appSubnets = []) {
   if (!Array.isArray(appSubnets) || appSubnets.length < 1) {
     return {};
   }
 
-  const resources = buildNetworkAcl(stage, DB_SUBNET);
+  const resources = buildNetworkAcl(DB_SUBNET);
 
   appSubnets.forEach((subnet, index) => {
     Object.assign(

--- a/src/natgw.js
+++ b/src/natgw.js
@@ -21,12 +21,11 @@ function buildEIP(position) {
 /**
  * Build a NatGateway in a given AZ
  *
- * @param {String} stage
  * @param {Number} position
  * @param {String} zone
  * @return {Object}
  */
-function buildNatGateway(stage, position, zone) {
+function buildNatGateway(position, zone) {
   const cfName = `NatGateway${position}`;
   return {
     [cfName]: {
@@ -39,10 +38,6 @@ function buildNatGateway(stage, position, zone) {
           Ref: `${PUBLIC_SUBNET}Subnet${position}`,
         },
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {

--- a/src/subnet_groups.js
+++ b/src/subnet_groups.js
@@ -3,11 +3,10 @@ const { DB_SUBNET } = require('./constants');
 /**
  * Build an RDSubnetGroup for a given number of zones
  *
- * @param {String} stage
  * @param {Objects} params
  * @return {Object}
  */
-function buildRDSSubnetGroup(stage, { name = 'RDSSubnetGroup', numZones = 0 } = {}) {
+function buildRDSSubnetGroup({ name = 'RDSSubnetGroup', numZones = 0 } = {}) {
   if (numZones < 1) {
     return {};
   }
@@ -28,12 +27,6 @@ function buildRDSSubnetGroup(stage, { name = 'RDSSubnetGroup', numZones = 0 } = 
           Ref: 'AWS::StackName',
         },
         SubnetIds: subnetIds,
-        Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
-        ],
       },
     },
   };
@@ -74,11 +67,10 @@ function buildElastiCacheSubnetGroup({ name = 'ElastiCacheSubnetGroup', numZones
 /**
  * Build an RedshiftSubnetGroup for a given number of zones
  *
- * @param {String} stage
  * @param {Object} params
  * @return {Object}
  */
-function buildRedshiftSubnetGroup(stage, { name = 'RedshiftSubnetGroup', numZones = 0 } = {}) {
+function buildRedshiftSubnetGroup({ name = 'RedshiftSubnetGroup', numZones = 0 } = {}) {
   if (numZones < 1) {
     return {};
   }
@@ -96,12 +88,6 @@ function buildRedshiftSubnetGroup(stage, { name = 'RedshiftSubnetGroup', numZone
           Ref: 'AWS::StackName',
         },
         SubnetIds: subnetIds,
-        Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
-        ],
       },
     },
   };

--- a/src/vpc.js
+++ b/src/vpc.js
@@ -1,7 +1,6 @@
 /**
  * Build a VPC
  *
- * @param {String} stage Serverless Stage
  * @param {Object} params
  * @return {Object}
  */

--- a/src/vpc.js
+++ b/src/vpc.js
@@ -5,7 +5,7 @@
  * @param {Object} params
  * @return {Object}
  */
-function buildVpc(stage, { name = 'VPC', cidrBlock = '10.0.0.0/16' } = {}) {
+function buildVpc({ name = 'VPC', cidrBlock = '10.0.0.0/16' } = {}) {
   return {
     [name]: {
       Type: 'AWS::EC2::VPC',
@@ -15,10 +15,6 @@ function buildVpc(stage, { name = 'VPC', cidrBlock = '10.0.0.0/16' } = {}) {
         EnableDnsHostnames: true,
         InstanceTenancy: 'default',
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {
@@ -34,20 +30,15 @@ function buildVpc(stage, { name = 'VPC', cidrBlock = '10.0.0.0/16' } = {}) {
 /**
  * Build an InternetGateway
  *
- * @param {String} stage Serverless Stage
  * @param {Object} params
  * @return {Object}
  */
-function buildInternetGateway(stage, { name = 'InternetGateway' } = {}) {
+function buildInternetGateway({ name = 'InternetGateway' } = {}) {
   return {
     [name]: {
       Type: 'AWS::EC2::InternetGateway',
       Properties: {
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {
@@ -85,14 +76,13 @@ function buildInternetGatewayAttachment({ name = 'InternetGatewayAttachment' } =
 /**
  * Create a subnet
  *
- * @param {String} stage Serverless Stage
  * @param {String} name Name of subnet
  * @param {Number} position Subnet position
  * @param {String} zone Availability zone
  * @param {String} cidrBlock Subnet CIDR block
  * @return {Object}
  */
-function buildSubnet(stage, name, position, zone, cidrBlock) {
+function buildSubnet(name, position, zone, cidrBlock) {
   const cfName = `${name}Subnet${position}`;
   return {
     [cfName]: {
@@ -101,10 +91,6 @@ function buildSubnet(stage, name, position, zone, cidrBlock) {
         AvailabilityZone: zone,
         CidrBlock: cidrBlock,
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {
@@ -132,13 +118,12 @@ function buildSubnet(stage, name, position, zone, cidrBlock) {
 /**
  * Build a RouteTable in a given AZ
  *
- * @param {String} stage Serverless Stage
  * @param {String} name
  * @param {Number} position
  * @param {String} zone
  * @return {Object}
  */
-function buildRouteTable(stage, name, position, zone) {
+function buildRouteTable(name, position, zone) {
   const cfName = `${name}RouteTable${position}`;
   return {
     [cfName]: {
@@ -148,10 +133,6 @@ function buildRouteTable(stage, name, position, zone) {
           Ref: 'VPC',
         },
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {
@@ -237,11 +218,10 @@ function buildRoute(name, position, { NatGatewayId = null, GatewayId = null } = 
 /**
  * Build a SecurityGroup to be used by Lambda's when they execute.
  *
- * @param {String} stage
  * @param {Object} params
  * @return {Object}
  */
-function buildLambdaSecurityGroup(stage, { name = 'LambdaExecutionSecurityGroup' } = {}) {
+function buildLambdaSecurityGroup({ name = 'LambdaExecutionSecurityGroup' } = {}) {
   return {
     [name]: {
       Type: 'AWS::EC2::SecurityGroup',
@@ -251,10 +231,6 @@ function buildLambdaSecurityGroup(stage, { name = 'LambdaExecutionSecurityGroup'
           Ref: 'VPC',
         },
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {

--- a/src/vpce.js
+++ b/src/vpce.js
@@ -111,11 +111,10 @@ function buildEndpointServices({ services = [], numZones = 0 } = {}) {
 /**
  * Build a SecurityGroup to allow the Lambda's access to VPC endpoints over HTTPS.
  *
- * @param {String} stage
  * @param {Object} params
  * @return {Object}
  */
-function buildLambdaVPCEndpointSecurityGroup(stage, { name = 'LambdaEndpointSecurityGroup' } = {}) {
+function buildLambdaVPCEndpointSecurityGroup({ name = 'LambdaEndpointSecurityGroup' } = {}) {
   return {
     [name]: {
       Type: 'AWS::EC2::SecurityGroup',
@@ -135,10 +134,6 @@ function buildLambdaVPCEndpointSecurityGroup(stage, { name = 'LambdaEndpointSecu
           },
         ],
         Tags: [
-          {
-            Key: 'STAGE',
-            Value: stage,
-          },
           {
             Key: 'Name',
             Value: {


### PR DESCRIPTION
Serverless automatically adds the STAGE tag to the CloudFormation stack which will add it to all taggable resources created by the stack.

This will reduce the size of the generated CloudFormation template and allow drift detection to work more reliably.