### PR TITLE
Automatically update the VPC configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ plugins:
   - serverless-vpc-plugin
 
 provider:
+  # you do not need to provide the "vpc" section as this plugin will populate it automatically
   vpc:
     securityGroupIds:
       -  # plugin will add LambdaExecutionSecurityGroup to this list
     subnetIds:
-      -  # plugin will add the provisioned "Application" subnets
+      -  # plugin will add the "Application" subnets to this list
 
 custom:
   vpcConfig:
@@ -103,3 +104,10 @@ custom:
       - kms
       - secretsmanager
 ```
+
+## CloudFormation Outputs
+
+After executing `serverless deploy`, the following CloudFormation Stack Outputs will be provided:
+
+- `VPC`: VPC logical resource ID
+- `LambdaExecutionSecurityGroup`: Security Group logical resource ID that the Lambda functions use when executing within the VPC

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin provisions the following resources:
 - `AWS::EC2::VPC`
 - `AWS::EC2::InternetGateway` (for outbound internet access)
 - `AWS::EC2::VPCGatewayAttachment` (to attach the `InternetGateway` to the VPC)
-- `AWS::EC2::SecurityGroup` (to execute Lambda functions)
+- `AWS::EC2::SecurityGroup` (to execute Lambda functions [`LambdaExecutionSecurityGroup`])
 
 If the VPC is allocated a /16 subnet, each availability zone within the region will be allocated a /20 subnet. Within each availability zone, this plugin will further divide the subnets:
 
@@ -66,14 +66,9 @@ plugins:
 provider:
   vpc:
     securityGroupIds:
-      - Ref: LambdaExecutionSecurityGroup # this plugin will create this security group for you
-    subnetIds: # if specifying zones below, include the same number of subnets here
-      - Ref: AppSubnet1
-      - Ref: AppSubnet2
-      - Ref: AppSubnet3
-      #- Ref: AppSubnet4
-      #- Ref: AppSubnet5
-      #- Ref: AppSubnet6
+      -  # plugin will add LambdaExecutionSecurityGroup to this list
+    subnetIds:
+      -  # plugin will add the provisioned "Application" subnets
 
 custom:
   vpcConfig:

--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,7 @@
   },
   "main": "s3.js",
   "scripts": {
+    "package": "SLS_DEBUG=* npx sls package",
     "deploy": "npx sls deploy -v --force",
     "remove": "npx sls remove -v",
     "test": "npx sls invoke -f s3"

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "aws-sdk": "2.290.0",
-    "serverless": "1.39.1",
-    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#master"
+    "serverless": "1.40.0",
+    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#jp-gh35"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "aws-sdk": "2.290.0",
     "serverless": "1.40.0",
-    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#jp-gh35"
+    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#master"
   }
 }

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -10,13 +10,6 @@ provider:
   deploymentBucket:
     serverSideEncryption: AES256
   endpointType: regional
-  vpc:
-    securityGroupIds:
-      - Ref: LambdaExecutionSecurityGroup
-    subnetIds:
-      - Ref: AppSubnet1
-      - Ref: AppSubnet2
-      - Ref: AppSubnet3
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-plugin",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-plugin",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "engines": {
     "node": ">=8.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,9 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'after:package:finalize': this.afterPackageFinalize.bind(this),
+      'after:aws:package:finalize:mergeCustomProviderResources': this.afterPackageFinalize.bind(
+        this,
+      ),
     };
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,13 +30,13 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'after:aws:package:finalize:mergeCustomProviderResources': this.afterPackageFinalize.bind(
+      'before:aws:package:finalize:mergeCustomProviderResources': this.beforePackageFinalize.bind(
         this,
       ),
     };
   }
 
-  async afterPackageFinalize() {
+  async beforePackageFinalize() {
     let cidrBlock = '10.0.0.0/16';
     let zones = [];
     let services = ['s3', 'dynamodb'];

--- a/src/index.js
+++ b/src/index.js
@@ -30,13 +30,11 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'before:aws:package:finalize:mergeCustomProviderResources': this.beforePackageFinalize.bind(
-        this,
-      ),
+      'after:package:initialize': this.afterInitialize.bind(this),
     };
   }
 
-  async beforePackageFinalize() {
+  async afterInitialize() {
     let cidrBlock = '10.0.0.0/16';
     let zones = [];
     let services = ['s3', 'dynamodb'];

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'before:deploy:resources': this.afterInitialize.bind(this),
-      // 'after:package:initialize': this.afterInitialize.bind(this),
+      // 'before:deploy:deploy': this.afterInitialize.bind(this),
+      'after:package:initialize': this.afterInitialize.bind(this),
     };
   }
 
@@ -167,10 +167,7 @@ class ServerlessVpcPlugin {
     }
 
     this.serverless.cli.log('Updating Lambda VPC configuration');
-    const { vpc } = providerObj;
-    if (!vpc) {
-      providerObj.vpc = {};
-    }
+    const { vpc = {} } = providerObj;
 
     if (!Array.isArray(vpc.securityGroupIds)) {
       vpc.securityGroupIds = [];

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,11 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'after:package:initialize': this.afterPackageInitialize.bind(this),
+      'after:aws:package:finalize': this.afterPackageFinalize.bind(this),
     };
   }
 
-  async afterPackageInitialize() {
+  async afterPackageFinalize() {
     let cidrBlock = '10.0.0.0/16';
     let zones = [];
     let services = ['s3', 'dynamodb'];
@@ -114,7 +114,7 @@ class ServerlessVpcPlugin {
     );
 
     const providerObj = this.serverless.service.provider;
-    const resources = this.serverless.service.resources.Resources;
+    const resources = providerObj.compiledCloudFormationTemplate.Resources;
 
     Object.assign(
       resources,

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,11 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'after:aws:package:finalize': this.afterPackageFinalize.bind(this),
+      'after:package:initialize': this.afterInitialize.bind(this),
     };
   }
 
-  async afterPackageFinalize() {
+  async afterInitialize() {
     let cidrBlock = '10.0.0.0/16';
     let zones = [];
     let services = ['s3', 'dynamodb'];
@@ -179,6 +179,7 @@ class ServerlessVpcPlugin {
     for (let i = 1; i <= numZones; i += 1) {
       vpc.subnetIds.push({ Ref: `${APP_SUBNET}Subnet${i}` });
     }
+    this.serverless.service.provider.vpc = vpc;
     this.serverless.cli.log('VPC Configuration:', this.serverless.service.provider.vpc);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,12 +30,11 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      // 'before:deploy:deploy': this.afterInitialize.bind(this),
-      'after:package:initialize': this.afterInitialize.bind(this),
+      'before:deploy:deploy': this.beforeDeploy.bind(this),
     };
   }
 
-  async afterInitialize() {
+  async beforeDeploy() {
     let cidrBlock = '10.0.0.0/16';
     let zones = [];
     let services = ['s3', 'dynamodb'];

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,11 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'after:package:initialize': this.afterInitialize.bind(this),
+      'before:package:initialize': this.beforePackageInitialize.bind(this),
     };
   }
 
-  async afterInitialize() {
+  async beforePackageInitialize() {
     let cidrBlock = '10.0.0.0/16';
     let zones = [];
     let services = ['s3', 'dynamodb'];
@@ -179,6 +179,7 @@ class ServerlessVpcPlugin {
     for (let i = 1; i <= numZones; i += 1) {
       vpc.subnetIds.push({ Ref: `${APP_SUBNET}Subnet${i}` });
     }
+    this.serverless.cli.log('VPC Configuration:', this.serverless.service.provider.vpc);
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,11 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'before:package:initialize': this.beforePackageInitialize.bind(this),
+      'after:package:initialize': this.afterPackageInitialize.bind(this),
     };
   }
 
-  async beforePackageInitialize() {
+  async afterPackageInitialize() {
     let cidrBlock = '10.0.0.0/16';
     let zones = [];
     let services = ['s3', 'dynamodb'];

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ class ServerlessVpcPlugin {
     );
 
     const providerObj = this.serverless.service.provider;
-    const resources = providerObj.compiledCloudFormationTemplate.Resources;
+    const resources = this.serverless.service.resources.Resources;
 
     Object.assign(
       resources,

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,11 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'before:deploy:deploy': this.beforeDeploy.bind(this),
+      'after:package:finalize': this.afterPackageFinalize.bind(this),
     };
   }
 
-  async beforeDeploy() {
+  async afterPackageFinalize() {
     let cidrBlock = '10.0.0.0/16';
     let zones = [];
     let services = ['s3', 'dynamodb'];

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,8 @@ class ServerlessVpcPlugin {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'after:package:initialize': this.afterInitialize.bind(this),
+      'before:deploy:resources': this.afterInitialize.bind(this),
+      // 'after:package:initialize': this.afterInitialize.bind(this),
     };
   }
 
@@ -170,10 +171,12 @@ class ServerlessVpcPlugin {
     if (!vpc) {
       providerObj.vpc = {};
     }
+
     if (!Array.isArray(vpc.securityGroupIds)) {
       vpc.securityGroupIds = [];
     }
     vpc.securityGroupIds.push({ Ref: 'LambdaExecutionSecurityGroup' });
+
     if (!Array.isArray(vpc.subnetIds)) {
       vpc.subnetIds = [];
     }

--- a/src/index.js
+++ b/src/index.js
@@ -411,13 +411,14 @@ class ServerlessVpcPlugin {
   static buildOutputs() {
     const outputs = {
       VPC: {
-        Description: 'VPC Resource ID',
+        Description: 'VPC logical resource ID',
         Value: {
           Ref: 'VPC',
         },
       },
       LambdaExecutionSecurityGroup: {
-        Description: 'Security group the Lambda functions use for execution within the VPC',
+        Description:
+          'Security Group logical resource ID that the Lambda functions use when executing within the VPC',
         Value: {
           Ref: 'LambdaExecutionSecurityGroup',
         },


### PR DESCRIPTION
Fixes #35 

- automatically update the Serverless AWS `provider` VPC configuration based on what is provisioned
- add CloudFormation `Outputs` with the VPC and LambdaExecutionSecurityGroup logical resource IDs