### PR TITLE
Optionally provision an Instance Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ This plugin provisions the following resources:
 
 If the VPC is allocated a /16 subnet, each availability zone within the region will be allocated a /20 subnet. Within each availability zone, this plugin will further divide the subnets:
 
-- `AWS::EC2::Subnet` "Application" (/21) - default route is either `InternetGateway` or `NatGateway`
+- `AWS::EC2::Subnet` "Application" (/21) - default route is either `InternetGateway`, `NatGateway` or `BastionInstance`
 - `AWS::EC2::Subnet` "Public" (/22) - default route set `InternetGateway`
 - `AWS::EC2::Subnet` "Database" (/22) - no default route set in routing table
 
 The subnetting layout was heavily inspired by the now shutdown [Skyliner](https://skyliner.io) platform. 😞
 
 Optionally, this plugin can also create `AWS::EC2::NatGateway` instances in each availability zone which requires provisioning `AWS::EC2::EIP` resources (AWS limits you to 5 per VPC, so if you want to provision your VPC across all 6 us-east availability zones, you'll need to request an VPC EIP limit increase from AWS).
+
+Instead of using the managed `AWS::EC2::NatGateway` instances, this plugin can also provision a single `t2.micro` NAT instance in `PublicSubnet1` which will allow HTTP/HTTPS traffic from the "Application" subnets to reach the Internet.
 
 Any Lambda functions executing with the "Application" subnet will only be able to access:
 
@@ -34,7 +36,7 @@ Any Lambda functions executing with the "Application" subnet will only be able t
 - DAX clusters (provisioned within the "DB" subnet)
 - Neptune clusters (provisioned with the "DB" subnet)
 
-If your Lambda functions need to access the internet, then you _MUST_ provision `NatGateway` resources.
+If your Lambda functions need to access the internet, then you _MUST_ provision `NatGateway` resources or a bastion host.
 
 By default, `AWS::EC2::VPCEndpoint` "Gateway" endpoints for S3 and DynamoDB will be provisioned within each availability zone to provide internal access to these services (there is no additional charge for using Gateway Type VPC endpoints). You can selectively control which `AWS::EC2::VPCEndpoint` "Interface" endpoints are available within your VPC using the `services` configuration option below. Not all AWS services are available in every region, so the plugin will query AWS to validate the services you have selected and notify you if any changes are required (there is an additional charge for using Interface Type VPC endpoints).
 
@@ -90,6 +92,9 @@ custom:
     # Whether to enable VPC flow logging to an S3 bucket
     createFlowLogs: false
 
+    # Whether to create a bastion NAT instance gateway
+    createBastionHost: false
+
     # optionally specify AZs (defaults to auto-discover all availabile AZs)
     zones:
       - us-east-1a
@@ -111,3 +116,4 @@ After executing `serverless deploy`, the following CloudFormation Stack Outputs 
 
 - `VPC`: VPC logical resource ID
 - `LambdaExecutionSecurityGroup`: Security Group logical resource ID that the Lambda functions use when executing within the VPC
+- `BastionPublicDnsName`: Public DNS name of the bastion host, if provisioned

--- a/__tests__/bastion.test.js
+++ b/__tests__/bastion.test.js
@@ -1,0 +1,216 @@
+const {
+  buildBastionIamInstanceProfile,
+  buildBastionIamRole,
+  buildBastionInstance,
+  buildBastionSecurityGroup,
+} = require('../src/bastion');
+
+describe('bastion', () => {
+  describe('#buildBastionIamInstanceProfile', () => {
+    it('builds an instance profile', () => {
+      const expected = {
+        BastionInstanceProfile: {
+          Type: 'AWS::IAM::InstanceProfile',
+          Properties: {
+            Roles: [
+              {
+                Ref: 'BastionIamRole',
+              },
+            ],
+          },
+        },
+      };
+
+      const actual = buildBastionIamInstanceProfile();
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
+  describe('#buildBastionIamRole', () => {
+    it('builds an IAM role', () => {
+      const expected = {
+        BastionIamRole: {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            AssumeRolePolicyDocument: {
+              Statement: [
+                {
+                  Principal: {
+                    Service: 'ec2.amazonaws.com',
+                  },
+                  Effect: 'Allow',
+                  Action: 'sts:AssumeRole',
+                },
+              ],
+            },
+            ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'],
+          },
+        },
+      };
+
+      const actual = buildBastionIamRole();
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
+  describe('#buildBastionSecurityGroup', () => {
+    it('builds a security group', () => {
+      const expected = {
+        BastionSecurityGroup: {
+          Type: 'AWS::EC2::SecurityGroup',
+          Properties: {
+            GroupDescription: 'Bastion Host',
+            VpcId: {
+              Ref: 'VPC',
+            },
+            SecurityGroupEgress: [
+              {
+                Description: 'Allow outbound HTTP access to the Internet',
+                IpProtocol: 'tcp',
+                FromPort: 80,
+                ToPort: 80,
+                CidrIp: '0.0.0.0/0',
+              },
+              {
+                Description: 'Allow outbound HTTPS access to the Internet',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+                CidrIp: '0.0.0.0/0',
+              },
+            ],
+            SecurityGroupIngress: [
+              {
+                Description: 'Allow inbound SSH access to the NAT instance',
+                IpProtocol: 'tcp',
+                FromPort: 22,
+                ToPort: 22,
+                CidrIp: '0.0.0.0/0',
+              },
+              {
+                Description: 'Allow inbound HTTP traffic from AppSubnet1',
+                IpProtocol: 'tcp',
+                FromPort: 80,
+                ToPort: 80,
+                CidrIp: '10.0.0.0/21',
+              },
+              {
+                Description: 'Allow inbound HTTPS traffic from AppSubnet1',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+                CidrIp: '10.0.0.0/21',
+              },
+              {
+                Description: 'Allow inbound HTTP traffic from AppSubnet2',
+                IpProtocol: 'tcp',
+                FromPort: 80,
+                ToPort: 80,
+                CidrIp: '10.0.6.0/21',
+              },
+              {
+                Description: 'Allow inbound HTTPS traffic from AppSubnet2',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+                CidrIp: '10.0.6.0/21',
+              },
+            ],
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  'Fn::Join': [
+                    '-',
+                    [
+                      {
+                        Ref: 'AWS::StackName',
+                      },
+                      'bastion',
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      const actual = buildBastionSecurityGroup({ subnets: ['10.0.0.0/21', '10.0.6.0/21'] });
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
+  describe('#buildBastionInstance', () => {
+    it('builds an EC2 instance', () => {
+      const expected = {
+        BastionInstance: {
+          Type: 'AWS::EC2::Instance',
+          DependsOn: 'InternetGatewayAttachment',
+          Properties: {
+            AvailabilityZone: {
+              'Fn::Select': ['0', ['us-east-1a', 'us-east-1b']],
+            },
+            BlockDeviceMappings: [
+              {
+                DeviceName: '/dev/xvda',
+                Ebs: {
+                  VolumeSize: 30,
+                  VolumeType: 'gp2',
+                  DeleteOnTermination: true,
+                  SnapshotId: 'snap-067424abc11f77a61',
+                },
+              },
+            ],
+            IamInstanceProfile: {
+              Ref: 'BastionInstanceProfile',
+            },
+            ImageId: 'ami-00a9d4a05375b2763', // amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs
+            InstanceType: 't2.micro',
+            Monitoring: false,
+            NetworkInterfaces: [
+              {
+                AssociatePublicIpAddress: true,
+                DeleteOnTermination: true,
+                Description: 'eth0',
+                DeviceIndex: '0',
+                GroupSet: [
+                  {
+                    Ref: 'BastionSecurityGroup',
+                  },
+                ],
+                SubnetId: {
+                  Ref: 'PublicSubnet1',
+                },
+              },
+            ],
+            SourceDestCheck: false,
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  'Fn::Join': [
+                    '-',
+                    [
+                      {
+                        Ref: 'AWS::StackName',
+                      },
+                      'bastion',
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      const actual = buildBastionInstance({ zones: ['us-east-1a', 'us-east-1b'] });
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+});

--- a/__tests__/bastion.test.js
+++ b/__tests__/bastion.test.js
@@ -44,7 +44,6 @@ describe('bastion', () => {
                 },
               ],
             },
-            ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'],
           },
         },
       };

--- a/__tests__/vpc.test.js
+++ b/__tests__/vpc.test.js
@@ -296,10 +296,34 @@ describe('vpc', () => {
       expect.assertions(1);
     });
 
+    it('builds a route with an Instance Gateway', () => {
+      const expected = {
+        AppRoute1: {
+          Type: 'AWS::EC2::Route',
+          Properties: {
+            DestinationCidrBlock: '0.0.0.0/0',
+            InstanceId: {
+              Ref: 'BastionInstance',
+            },
+            RouteTableId: {
+              Ref: 'AppRouteTable1',
+            },
+          },
+        },
+      };
+      const actual = buildRoute('App', 1, {
+        InstanceId: 'BastionInstance',
+      });
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+
     it('throws an error if no gateway provided', () => {
       expect(() => {
         buildRoute('App', 1);
-      }).toThrow('Unable to create route: either NatGatewayId or GatewayId must be provided');
+      }).toThrow(
+        'Unable to create route: either NatGatewayId, GatewayId or InstanceId must be provided',
+      );
       expect.assertions(1);
     });
   });

--- a/example/package.json
+++ b/example/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "aws-sdk": "2.290.0",
     "serverless": "1.40.0",
-    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#master"
+    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#jp-gh36"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "aws-sdk": "2.290.0",
     "serverless": "1.40.0",
-    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#jp-gh36"
+    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#master"
   }
 }

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -40,6 +40,7 @@ custom:
     createDbSubnet: true
     createNetworkAcl: true
     createFlowLogs: true
+    createBastionHost: true
     zones:
       - us-east-1a
       - us-east-1b

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2590,24 +2590,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2617,12 +2621,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -2631,34 +2637,40 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2667,25 +2679,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2694,13 +2710,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2716,7 +2734,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2730,13 +2749,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2745,7 +2766,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2754,7 +2776,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2764,18 +2787,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -2783,13 +2809,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -2797,12 +2825,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -2811,7 +2841,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2820,7 +2851,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -2828,13 +2860,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+          "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2845,7 +2879,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2863,7 +2898,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2873,13 +2909,15 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+          "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2889,7 +2927,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2901,18 +2940,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -2920,19 +2962,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2942,19 +2987,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2966,7 +3014,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2974,7 +3023,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2989,7 +3039,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2998,42 +3049,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -3043,7 +3101,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3052,7 +3111,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3060,13 +3120,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3081,13 +3143,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3096,12 +3160,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "engines": {
     "node": ">=8.0"
   },

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -189,6 +189,22 @@ function buildBastionInstance({ name = 'BastionInstance', zones = [] } = {}) {
           Ref: 'PublicSubnet1',
         },
         SourceDestCheck: false,
+        Tags: [
+          {
+            Key: 'Name',
+            Value: {
+              'Fn::Join': [
+                '-',
+                [
+                  {
+                    Ref: 'AWS::StackName',
+                  },
+                  'bastion',
+                ],
+              ],
+            },
+          },
+        ],
       },
     },
   };

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -140,13 +140,20 @@ function buildBastionSecurityGroup({ name = 'BastionSecurityGroup', subnets = []
  * @param {Object} params
  * @return {Object}
  */
-function buildBastionInstance({ name = 'BastionInstance', zones = [], subnets = [] } = {}) {
+function buildBastionInstance({ name = 'BastionInstance' } = {}) {
   return {
     [name]: {
       Type: 'AWS::EC2::Instance',
       DependsOn: 'InternetGatewayAttachment',
       Properties: {
-        AvailabilityZone: zones[0],
+        AvailabilityZone: {
+          'Fn::Select': [
+            '0',
+            {
+              'Fn::GetAZs': '',
+            },
+          ],
+        },
         BlockDeviceMappings: [
           {
             DeviceName: '/dev/xvda',
@@ -169,7 +176,9 @@ function buildBastionInstance({ name = 'BastionInstance', zones = [], subnets = 
             Ref: 'BastionSecurityGroup',
           },
         ],
-        SubnetId: subnets[0],
+        SubnetId: {
+          Ref: 'PublicSubnet1',
+        },
         SourceDestCheck: false,
       },
     },

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -174,7 +174,8 @@ function buildBastionInstance({ name = 'BastionInstance', zones = [] } = {}) {
           {
             AssociatePublicIpAddress: true,
             DeleteOnTermination: true,
-            DeviceIndex: 'eth0',
+            Description: 'eth0',
+            DeviceIndex: '0',
             SubnetId: {
               Ref: 'PublicSubnet1',
             },

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -22,7 +22,6 @@ function buildBastionIamRole({ name = 'BastionIamRole' } = {}) {
             },
           ],
         },
-        ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'],
       },
     },
   };

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -170,6 +170,16 @@ function buildBastionInstance({ name = 'BastionInstance', zones = [] } = {}) {
         ImageId: 'ami-00a9d4a05375b2763', // amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs
         InstanceType: 't2.micro',
         Monitoring: false,
+        NetworkInterfaces: [
+          {
+            AssociatePublicIpAddress: true,
+            DeleteOnTermination: true,
+            DeviceIndex: 'eth0',
+            SubnetId: {
+              Ref: 'PublicSubnet1',
+            },
+          },
+        ],
         SecurityGroupIds: [
           {
             Ref: 'BastionSecurityGroup',

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -186,9 +186,6 @@ function buildBastionInstance({ name = 'BastionInstance', zones = [] } = {}) {
             Ref: 'BastionSecurityGroup',
           },
         ],
-        SubnetId: {
-          Ref: 'PublicSubnet1',
-        },
         SourceDestCheck: false,
         Tags: [
           {

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -176,14 +176,14 @@ function buildBastionInstance({ name = 'BastionInstance', zones = [] } = {}) {
             DeleteOnTermination: true,
             Description: 'eth0',
             DeviceIndex: '0',
+            GroupSet: [
+              {
+                Ref: 'BastionSecurityGroup',
+              },
+            ],
             SubnetId: {
               Ref: 'PublicSubnet1',
             },
-          },
-        ],
-        SecurityGroupIds: [
-          {
-            Ref: 'BastionSecurityGroup',
           },
         ],
         SourceDestCheck: false,

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -1,0 +1,175 @@
+const { APP_SUBNET } = require('./constants');
+
+/**
+ * Build a SecurityGroup to be used by the bastion host
+ *
+ * @param {Object} params
+ * @return {Object}
+ */
+function buildBastionSecurityGroup({ name = 'BastionSecurityGroup', subnets = [] } = {}) {
+  const SecurityGroupIngress = [
+    {
+      Description: 'Allow inbound SSH access to the NAT instance',
+      IpProtocol: 'tcp',
+      FromPort: 22,
+      ToPort: 22,
+      CidrIp: '0.0.0.0/0',
+    },
+  ];
+
+  if (Array.isArray(subnets) && subnets.length > 0) {
+    subnets.forEach((subnet, index) => {
+      const position = index + 1;
+
+      const http = {
+        Description: `Allow inbound HTTP traffic from ${APP_SUBNET}Subnet${position}`,
+        IpProtocol: 'tcp',
+        FromPort: 80,
+        ToPort: 80,
+        CidrIp: subnet,
+      };
+      const https = {
+        Description: `Allow inbound HTTPS traffic from ${APP_SUBNET}Subnet${position}`,
+        IpProtocol: 'tcp',
+        FromPort: 443,
+        ToPort: 443,
+        CidrIp: subnet,
+      };
+      SecurityGroupIngress.push(http, https);
+    });
+  }
+
+  return {
+    [name]: {
+      Type: 'AWS::EC2::SecurityGroup',
+      Properties: {
+        GroupDescription: 'Bastion Host',
+        VpcId: {
+          Ref: 'VPC',
+        },
+        SecurityGroupEgress: [
+          {
+            Description: 'Allow outbound HTTP access to the Internet',
+            IpProtocol: 'tcp',
+            FromPort: 80,
+            ToPort: 80,
+            CidrIp: '0.0.0.0/0',
+          },
+          {
+            Description: 'Allow outbound HTTPS access to the Internet',
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            CidrIp: '0.0.0.0/0',
+          },
+        ],
+        SecurityGroupIngress,
+        Tags: [
+          {
+            Key: 'Name',
+            Value: {
+              'Fn::Join': [
+                '-',
+                [
+                  {
+                    Ref: 'AWS::StackName',
+                  },
+                  'bastion',
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+/**
+ * Build the Bastion launch configuration
+ *
+ * @param {Object} params
+ * @return {Object}
+ */
+function buildBastionLaunchConfiguration({ name = 'BastionLaunchConfiguration' } = {}) {
+  return {
+    [name]: {
+      Type: 'AWS::AutoScaling::LaunchConfiguration',
+      Properties: {
+        AssociatePublicIpAddress: true,
+        BlockDeviceMappings: [
+          {
+            DeviceName: '/dev/xvda',
+            Ebs: {
+              VolumeSize: 30,
+              VolumeType: 'gp2',
+              DeleteOnTermination: true,
+              SnapshotId: 'snap-067424abc11f77a61',
+            },
+          },
+        ],
+        ImageId: 'ami-00a9d4a05375b2763', // amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs
+        InstanceMonitoring: false,
+        InstanceType: 't2.micro',
+        SecurityGroups: [
+          {
+            Ref: 'BastionSecurityGroup',
+          },
+        ],
+        SpotPrice: '0.0116', // https://aws.amazon.com/ec2/pricing/on-demand/
+      },
+    },
+  };
+}
+
+/**
+ * Build the Bastion host auto scaling group
+ *
+ * @param {Object} params
+ * @return {Object}
+ */
+function buildBastionAutoScalingGroup({
+  name = 'BastionAutoScalingGroup',
+  subnets = [],
+  zones = [],
+} = {}) {
+  return {
+    [name]: {
+      Type: 'AWS::AutoScaling::AutoScalingGroup',
+      DependsOn: 'InternetGatewayAttachment',
+      Properties: {
+        AvailabilityZones: zones,
+        DesiredCapacity: '1',
+        HealthCheckType: 'EC2',
+        LaunchConfigurationName: {
+          Ref: 'BastionLaunchConfiguration',
+        },
+        MaxSize: '1',
+        MinSize: '1',
+        Tags: [
+          {
+            Key: 'Name',
+            Value: {
+              'Fn::Join': [
+                '-',
+                [
+                  {
+                    Ref: 'AWS::StackName',
+                  },
+                  'asg',
+                ],
+              ],
+            },
+          },
+        ],
+        VPCZoneIdentifier: subnets,
+      },
+    },
+  };
+}
+
+exports.module = {
+  buildBastionAutoScalingGroup,
+  buildBastionLaunchConfiguration,
+  buildBastionSecurityGroup,
+};

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -140,19 +140,18 @@ function buildBastionSecurityGroup({ name = 'BastionSecurityGroup', subnets = []
  * @param {Object} params
  * @return {Object}
  */
-function buildBastionInstance({ name = 'BastionInstance' } = {}) {
+function buildBastionInstance({ name = 'BastionInstance', zones = [] } = {}) {
+  if (!Array.isArray(zones) || zones.length < 1) {
+    return {};
+  }
+
   return {
     [name]: {
       Type: 'AWS::EC2::Instance',
       DependsOn: 'InternetGatewayAttachment',
       Properties: {
         AvailabilityZone: {
-          'Fn::Select': [
-            '0',
-            {
-              'Fn::GetAZs': '',
-            },
-          ],
+          'Fn::Select': ['0', zones],
         },
         BlockDeviceMappings: [
           {
@@ -166,7 +165,7 @@ function buildBastionInstance({ name = 'BastionInstance' } = {}) {
           },
         ],
         IamInstanceProfile: {
-          'Fn::GetAtt': ['BastionInstanceProfile', 'Arn'],
+          Ref: 'BastionInstanceProfile',
         },
         ImageId: 'ami-00a9d4a05375b2763', // amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs
         InstanceType: 't2.micro',

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -164,7 +164,7 @@ function buildBastionInstance({ name = 'BastionInstance', zones = [], subnets = 
         ImageId: 'ami-00a9d4a05375b2763', // amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs
         InstanceType: 't2.micro',
         Monitoring: false,
-        SecurityGroupsIds: [
+        SecurityGroupIds: [
           {
             Ref: 'BastionSecurityGroup',
           },

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -176,7 +176,7 @@ function buildBastionInstance({ name = 'BastionInstance', zones = [], subnets = 
   };
 }
 
-exports.module = {
+module.exports = {
   buildBastionIamInstanceProfile,
   buildBastionIamRole,
   buildBastionInstance,

--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,9 @@ const { buildEndpointServices, buildLambdaVPCEndpointSecurityGroup } = require('
 const { buildEIP, buildNatGateway } = require('./natgw');
 const { buildLogBucket, buildLogBucketPolicy, buildVpcFlowLogs } = require('./flow_logs');
 const {
-  buildBastionAutoScalingGroup,
-  buildBastionLaunchConfiguration,
+  buildBastionIamRole,
+  buildBastionIamInstanceProfile,
+  buildBastionInstance,
   buildBastionSecurityGroup,
 } = require('./bastion');
 
@@ -135,6 +136,7 @@ class ServerlessVpcPlugin {
         numNatGateway: createNatGateway,
         createDbSubnet,
         createNetworkAcl,
+        createBastionHost,
       }),
       buildLambdaSecurityGroup(),
     );
@@ -418,16 +420,12 @@ class ServerlessVpcPlugin {
     }
 
     if (createBastionHost) {
-      this.serverless.cli.log('Creating bastion host in public subnet');
-
       Object.assign(
         resources,
+        buildBastionIamRole(),
+        buildBastionIamInstanceProfile(),
         buildBastionSecurityGroup({ subnets: subnets.get(APP_SUBNET) }),
-        buildBastionLaunchConfiguration(),
-        buildBastionAutoScalingGroup({
-          subnets: subnets.get(PUBLIC_SUBNET),
-          zones,
-        }),
+        buildBastionInstance({ subnets: subnets.get(PUBLIC_SUBNET), zones }),
       );
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -374,6 +374,8 @@ class ServerlessVpcPlugin {
       const params = {};
       if (numNatGateway > 0) {
         params.NatGatewayId = `NatGateway${(index % numNatGateway) + 1}`;
+      } else if (createBastionHost) {
+        params.InstanceId = 'BastionInstance';
       } else {
         params.GatewayId = 'InternetGateway';
       }
@@ -425,7 +427,7 @@ class ServerlessVpcPlugin {
         buildBastionIamRole(),
         buildBastionIamInstanceProfile(),
         buildBastionSecurityGroup({ subnets: subnets.get(APP_SUBNET) }),
-        buildBastionInstance(),
+        buildBastionInstance({ zones }),
       );
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ class ServerlessVpcPlugin {
     }
 
     const outputs = providerObj.compiledCloudFormationTemplate.Outputs;
-    Object.assign(outputs, ServerlessVpcPlugin.buildOutputs());
+    Object.assign(outputs, ServerlessVpcPlugin.buildOutputs(createBastionHost));
 
     this.serverless.cli.log('Updating Lambda VPC configuration');
     const { vpc = {} } = providerObj;
@@ -437,9 +437,10 @@ class ServerlessVpcPlugin {
   /**
    * Build CloudFormation Outputs on common resources
    *
+   * @param {Boolean} createBastionHost
    * @return {Object}
    */
-  static buildOutputs() {
+  static buildOutputs(createBastionHost = false) {
     const outputs = {
       VPC: {
         Description: 'VPC logical resource ID',
@@ -447,7 +448,7 @@ class ServerlessVpcPlugin {
           Ref: 'VPC',
         },
       },
-      LambdaExecutionSecurityGroup: {
+      LambdaExecutionSecurityGroupId: {
         Description:
           'Security Group logical resource ID that the Lambda functions use when executing within the VPC',
         Value: {
@@ -455,6 +456,15 @@ class ServerlessVpcPlugin {
         },
       },
     };
+
+    if (createBastionHost) {
+      outputs.BastionPublicDnsName = {
+        Description: 'Public DNS of Bastion host',
+        Value: {
+          'Fn::GetAtt': ['BastionInstance', 'PublicDnsName'],
+        },
+      };
+    }
 
     return outputs;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -425,7 +425,7 @@ class ServerlessVpcPlugin {
         buildBastionIamRole(),
         buildBastionIamInstanceProfile(),
         buildBastionSecurityGroup({ subnets: subnets.get(APP_SUBNET) }),
-        buildBastionInstance({ subnets: subnets.get(PUBLIC_SUBNET), zones }),
+        buildBastionInstance(),
       );
     }
 

--- a/src/vpc.js
+++ b/src/vpc.js
@@ -185,7 +185,11 @@ function buildRouteTableAssociation(name, position) {
  * @param {Object} params
  * @return {Object}
  */
-function buildRoute(name, position, { NatGatewayId = null, GatewayId = null } = {}) {
+function buildRoute(
+  name,
+  position,
+  { NatGatewayId = null, GatewayId = null, InstanceId = null } = {},
+) {
   const route = {
     Type: 'AWS::EC2::Route',
     Properties: {
@@ -204,8 +208,14 @@ function buildRoute(name, position, { NatGatewayId = null, GatewayId = null } = 
     route.Properties.GatewayId = {
       Ref: GatewayId,
     };
+  } else if (InstanceId) {
+    route.Properties.InstanceId = {
+      Ref: InstanceId,
+    };
   } else {
-    throw new Error('Unable to create route: either NatGatewayId or GatewayId must be provided');
+    throw new Error(
+      'Unable to create route: either NatGatewayId, GatewayId or InstanceId must be provided',
+    );
   }
 
   const cfName = `${name}Route${position}`;


### PR DESCRIPTION
Fixes #36 

While this PR doesn't implement spot instances, it does allow you to provision a single `t2.micro` NAT instance which can be used during development in place of the AWS managed NAT gateways.