### PR TITLE
Added 'subnetGroup' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ custom:
 
     # optional
     # can pick one of subnet groups in (rds / redshift / elasticache / dax)
+    # By default, if not specified, all of the subnet groups will be created.
     # ex) DAX is not available in ap-northeast-2 so I don't want to make DAX subnet group
-    subnetGroup:
+    subnetGroups:
       - rds
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ custom:
     services:
       - kms
       - secretsmanager
+
+    # optional
+    # can pick one of subnet groups in (rds / redshift / elasticache / dax)
+    # ex) DAX is not available in ap-northeast-2 so I don't want to make DAX subnet group
+    subnetGroup:
+      - rds
 ```
 
 ## CloudFormation Outputs

--- a/__tests__/subnet_groups.test.js
+++ b/__tests__/subnet_groups.test.js
@@ -7,7 +7,8 @@ const {
 } = require('../src/subnet_groups');
 
 describe('subnet_groups', () => {
-  let subnetGroupList = {}
+  let subnetGroupList = {};
+
   describe('#buildRDSSubnetGroup', () => {
     it('skips building an RDS subnet group with no zones', () => {
       const actual = buildRDSSubnetGroup();
@@ -37,7 +38,7 @@ describe('subnet_groups', () => {
           },
         },
       };
-      subnetGroupList['rds'] = expected
+      subnetGroupList.rds = expected;
       const actual = buildRDSSubnetGroup(2);
       expect(actual).toEqual(expected);
       expect.assertions(1);
@@ -102,7 +103,7 @@ describe('subnet_groups', () => {
           },
         },
       };
-      subnetGroupList['elasticache'] = expected
+      subnetGroupList.elasticache = expected;
       const actual = buildElastiCacheSubnetGroup(2);
       expect(actual).toEqual(expected);
       expect.assertions(1);
@@ -164,7 +165,7 @@ describe('subnet_groups', () => {
           },
         },
       };
-      subnetGroupList['redshift'] = expected
+      subnetGroupList.redshift = expected;
       const actual = buildRedshiftSubnetGroup(2);
       expect(actual).toEqual(expected);
       expect.assertions(1);
@@ -226,7 +227,7 @@ describe('subnet_groups', () => {
           },
         },
       };
-      subnetGroupList['dax'] = expected
+      subnetGroupList.dax = expected;
       const actual = buildDAXSubnetGroup(2);
       expect(actual).toEqual(expected);
       expect.assertions(1);
@@ -264,17 +265,23 @@ describe('subnet_groups', () => {
 
   describe('#buildSubnetGroups', () => {
     it('no subnetGroups option', () => {
-      const expected = Object.keys(subnetGroupList).reduce((acc, key) => Object.assign(acc, subnetGroupList[key]), {})
-      const actual = buildSubnetGroups(2, [])
+      const expected = Object.keys(subnetGroupList).reduce(
+        (acc, key) => Object.assign(acc, subnetGroupList[key]),
+        {},
+      );
+      const actual = buildSubnetGroups(2, []);
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
     it('get specific subnetGroups option', () => {
-      const getSubnetGroupsOptions = ['rds', 'redshift']
-      const expected = getSubnetGroupsOptions.reduce((acc, key) => Object.assign(acc, subnetGroupList[key]), {})
-      const actual = buildSubnetGroups(2, getSubnetGroupsOptions)
+      const getSubnetGroupsOptions = ['rds', 'redshift'];
+      const expected = getSubnetGroupsOptions.reduce(
+        (acc, key) => Object.assign(acc, subnetGroupList[key]),
+        {},
+      );
+      const actual = buildSubnetGroups(2, getSubnetGroupsOptions);
       expect(actual).toEqual(expected);
       expect.assertions(1);
-    })
+    });
   });
 });

--- a/__tests__/subnet_groups.test.js
+++ b/__tests__/subnet_groups.test.js
@@ -3,9 +3,11 @@ const {
   buildElastiCacheSubnetGroup,
   buildRedshiftSubnetGroup,
   buildDAXSubnetGroup,
+  buildSubnetGroups,
 } = require('../src/subnet_groups');
 
 describe('subnet_groups', () => {
+  let subnetGroupList = {}
   describe('#buildRDSSubnetGroup', () => {
     it('skips building an RDS subnet group with no zones', () => {
       const actual = buildRDSSubnetGroup();
@@ -35,6 +37,7 @@ describe('subnet_groups', () => {
           },
         },
       };
+      subnetGroupList['rds'] = expected
       const actual = buildRDSSubnetGroup(2);
       expect(actual).toEqual(expected);
       expect.assertions(1);
@@ -99,6 +102,7 @@ describe('subnet_groups', () => {
           },
         },
       };
+      subnetGroupList['elasticache'] = expected
       const actual = buildElastiCacheSubnetGroup(2);
       expect(actual).toEqual(expected);
       expect.assertions(1);
@@ -160,6 +164,7 @@ describe('subnet_groups', () => {
           },
         },
       };
+      subnetGroupList['redshift'] = expected
       const actual = buildRedshiftSubnetGroup(2);
       expect(actual).toEqual(expected);
       expect.assertions(1);
@@ -221,6 +226,7 @@ describe('subnet_groups', () => {
           },
         },
       };
+      subnetGroupList['dax'] = expected
       const actual = buildDAXSubnetGroup(2);
       expect(actual).toEqual(expected);
       expect.assertions(1);
@@ -254,5 +260,21 @@ describe('subnet_groups', () => {
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
+  });
+
+  describe('#buildSubnetGroups', () => {
+    it('no subnetGroups option', () => {
+      const expected = Object.keys(subnetGroupList).reduce((acc, key) => Object.assign(acc, subnetGroupList[key]), {})
+      const actual = buildSubnetGroups(2, [])
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+    it('get specific subnetGroups option', () => {
+      const getSubnetGroupsOptions = ['rds', 'redshift']
+      const expected = getSubnetGroupsOptions.reduce((acc, key) => Object.assign(acc, subnetGroupList[key]), {})
+      const actual = buildSubnetGroups(2, getSubnetGroupsOptions)
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    })
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ class ServerlessVpcPlugin {
     let createNatInstance = false;
     let createBastionHost = false;
     let bastionHostKeyName = null;
+    let subnetGroup = [];
 
     const { vpcConfig } = this.serverless.service.custom;
 
@@ -69,6 +70,9 @@ class ServerlessVpcPlugin {
       }
       if (Array.isArray(vpcConfig.services)) {
         services = vpcConfig.services.map(s => s.trim().toLowerCase());
+      }
+      if (Array.isArray(vpcConfig.subnetGroup) && vpcConfig.subnetGroup.length > 0) {
+        ({ subnetGroup } = vpcConfig);
       }
 
       if ('createDbSubnet' in vpcConfig && typeof vpcConfig.createDbSubnet === 'boolean') {
@@ -221,6 +225,8 @@ class ServerlessVpcPlugin {
     if (createDbSubnet) {
       if (numZones < 2) {
         this.serverless.cli.log('WARNING: less than 2 AZs; skipping subnet group provisioning');
+      } else if (subnetGroup.length > 0) {
+        Object.assign(resources, buildSubnetGroups(numZones, subnetGroup));
       } else {
         Object.assign(resources, buildSubnetGroups(numZones));
       }

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ class ServerlessVpcPlugin {
     let createNatInstance = false;
     let createBastionHost = false;
     let bastionHostKeyName = null;
-    let subnetGroup = [];
+    let subnetGroups = [];
 
     const { vpcConfig } = this.serverless.service.custom;
 
@@ -71,8 +71,8 @@ class ServerlessVpcPlugin {
       if (Array.isArray(vpcConfig.services)) {
         services = vpcConfig.services.map(s => s.trim().toLowerCase());
       }
-      if (Array.isArray(vpcConfig.subnetGroup) && vpcConfig.subnetGroup.length > 0) {
-        ({ subnetGroup } = vpcConfig);
+      if (Array.isArray(vpcConfig.subnetGroups) && vpcConfig.subnetGroups.length > 0) {
+        ({ subnetGroups } = vpcConfig);
       }
 
       if ('createDbSubnet' in vpcConfig && typeof vpcConfig.createDbSubnet === 'boolean') {
@@ -225,10 +225,8 @@ class ServerlessVpcPlugin {
     if (createDbSubnet) {
       if (numZones < 2) {
         this.serverless.cli.log('WARNING: less than 2 AZs; skipping subnet group provisioning');
-      } else if (subnetGroup.length > 0) {
-        Object.assign(resources, buildSubnetGroups(numZones, subnetGroup));
       } else {
-        Object.assign(resources, buildSubnetGroups(numZones));
+        Object.assign(resources, buildSubnetGroups(numZones, subnetGroups));
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const {
   buildLambdaSecurityGroup,
 } = require('./vpc');
 const { buildAppNetworkAcl, buildPublicNetworkAcl, buildDBNetworkAcl } = require('./nacl');
-const { buildSubnetGroups } = require('./subnet_groups');
+const { buildSubnetGroups, validSubnetGroups } = require('./subnet_groups');
 const { buildEndpointServices, buildLambdaVPCEndpointSecurityGroup } = require('./vpce');
 const { buildLogBucket, buildLogBucketPolicy, buildVpcFlowLogs } = require('./flow_logs');
 const { buildBastion } = require('./bastion');
@@ -226,6 +226,15 @@ class ServerlessVpcPlugin {
       if (numZones < 2) {
         this.serverless.cli.log('WARNING: less than 2 AZs; skipping subnet group provisioning');
       } else {
+        for (let i = 0; i < subnetGroups.length; i += 1) {
+          const subnetGrp = subnetGroups[i];
+          if (validSubnetGroups.indexOf(subnetGrp) === -1) {
+            throw new this.serverless.classes.Error(
+              `WARNING: '${subnetGrp}' is invalid subnetGroups option.
+    you should input among these options: ['rds', 'redshift', 'elasticache', 'dax']`,
+            );
+          }
+        }
         Object.assign(resources, buildSubnetGroups(numZones, subnetGroups));
       }
     }

--- a/src/subnet_groups.js
+++ b/src/subnet_groups.js
@@ -1,5 +1,7 @@
 const { DB_SUBNET } = require('./constants');
 
+const validSubnetGroups = ['rds', 'redshift', 'elasticache', 'dax'];
+
 /**
  * Build an RDSubnetGroup for a given number of zones
  *
@@ -133,6 +135,7 @@ function buildDAXSubnetGroup(numZones = 0, { name = 'DAXSubnetGroup' } = {}) {
  * Build the database subnet groups
  *
  * @param {Number} numZones Number of availability zones
+ * @param {Array} subnetGroups options of subnet groups
  * @return {Object}
  */
 function buildSubnetGroups(numZones = 0, subnetGroups = []) {
@@ -144,12 +147,14 @@ function buildSubnetGroups(numZones = 0, subnetGroups = []) {
     redshift: buildRedshiftSubnetGroup,
     elasticache: buildElastiCacheSubnetGroup,
     dax: buildDAXSubnetGroup,
+  };
+  function assembleSubnetGrp(acc, service) {
+    const builtSubnetGroup = subnetGroupList[service.toLowerCase()](numZones);
+    return Object.assign(acc, builtSubnetGroup);
   }
+
   if (subnetGroups.length > 0) {
-    return subnetGroups.reduce(function(acc, service) {
-      let builtSubnetGroup = subnetGroupList[service.toLowerCase()](numZones);
-      return Object.assign(acc, builtSubnetGroup);
-    }, {});
+    return subnetGroups.reduce(assembleSubnetGrp, {});
   }
   return Object.assign(
     {},
@@ -166,4 +171,5 @@ module.exports = {
   buildRDSSubnetGroup,
   buildRedshiftSubnetGroup,
   buildSubnetGroups,
+  validSubnetGroups,
 };

--- a/src/subnet_groups.js
+++ b/src/subnet_groups.js
@@ -135,19 +135,19 @@ function buildDAXSubnetGroup(numZones = 0, { name = 'DAXSubnetGroup' } = {}) {
  * @param {Number} numZones Number of availability zones
  * @return {Object}
  */
-function buildSubnetGroups(numZones = 0, subnetGroup = []) {
+function buildSubnetGroups(numZones = 0, subnetGroups = []) {
   if (numZones < 2) {
     return {};
   }
-  const subnetGroups = {
+  const subnetGroupList = {
     rds: buildRDSSubnetGroup,
     redshift: buildRedshiftSubnetGroup,
     elasticache: buildElastiCacheSubnetGroup,
     dax: buildDAXSubnetGroup,
   }
-  if (subnetGroup.length > 0) {
-    return subnetGroup.reduce(function(acc, service) {
-      let builtSubnetGroup = subnetGroups[service.toLowerCase()](numZones);
+  if (subnetGroups.length > 0) {
+    return subnetGroups.reduce(function(acc, service) {
+      let builtSubnetGroup = subnetGroupList[service.toLowerCase()](numZones);
       return Object.assign(acc, builtSubnetGroup);
     }, {});
   }

--- a/src/subnet_groups.js
+++ b/src/subnet_groups.js
@@ -135,7 +135,7 @@ function buildDAXSubnetGroup(numZones = 0, { name = 'DAXSubnetGroup' } = {}) {
  * @param {Number} numZones Number of availability zones
  * @return {Object}
  */
-function buildSubnetGroups(numZones = 0) {
+function buildSubnetGroups(numZones = 0, subnetGroup = []) {
   if (numZones < 2) {
     return {};
   }

--- a/src/subnet_groups.js
+++ b/src/subnet_groups.js
@@ -139,6 +139,18 @@ function buildSubnetGroups(numZones = 0) {
   if (numZones < 2) {
     return {};
   }
+  const subnetGroups = {
+    rds: buildRDSSubnetGroup,
+    redshift: buildRedshiftSubnetGroup,
+    elasticache: buildElastiCacheSubnetGroup,
+    dax: buildDAXSubnetGroup,
+  }
+  if (subnetGroup.length > 0) {
+    return subnetGroup.reduce(function(acc, service) {
+      let builtSubnetGroup = subnetGroups[service.toLowerCase()](numZones);
+      return Object.assign(acc, builtSubnetGroup);
+    }, {});
+  }
   return Object.assign(
     {},
     buildRDSSubnetGroup(numZones),


### PR DESCRIPTION
Hi.

I really appreciated to create this plugin. This is really nice~!

so I decided to use this plugin every project since now, but I faced some problem.

I work on `Seoul` region(ap-northeast-2).
`DAX` is not available in my region

so I added the option named `subnetGroup`.
subnetGroup can pick subnet groups which user want to create.

Adding this options, I could avoid the error this plugin tried to make **DAX** Subnet group.

please consider to be merged.

Thank you~!