### PR TITLE
Include Subnet Groups in outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,7 @@ After executing `serverless deploy`, the following CloudFormation Stack Outputs 
 - `LambdaExecutionSecurityGroup`: Security Group logical resource ID that the Lambda functions use when executing within the VPC
 - `BastionSSHUser`: SSH username to access the bastion host, if provisioned
 - `BastionEIP`: Elastic IP address associated to the bastion host, if provisioned
+- `RDSSubnetGroup`: SubnetGroup associated to RDS, if provisioned 
+- `ElastiCacheSubnetGroup`: SubnetGroup associated to ElastiCache, if provisioned
+- `RedshiftSubnetGroup`: SubnetGroup associated to Redshift, if provisioned
+- `DAXSubnetGroup`: SubnetGroup associated to DAX, if provisioned

--- a/__tests__/outputs.test.js
+++ b/__tests__/outputs.test.js
@@ -4,17 +4,33 @@ describe('outputs', () => {
   describe('#buildOutputs', () => {
     it('builds the outputs with no bastion host', () => {
       const expected = {
-        VPC: {
-          Description: 'VPC logical resource ID',
-          Value: {
-            Ref: 'VPC',
-          },
+        DAXSubnetGroup: {
+          Description: 'Subnet Group for dax',
+          Value: ['DAXSubnetGroup'],
+        },
+        ElastiCacheSubnetGroup: {
+          Description: 'Subnet Group for redshift',
+          Value: ['ElastiCacheSubnetGroup'],
         },
         LambdaExecutionSecurityGroupId: {
           Description:
             'Security Group logical resource ID that the Lambda functions use when executing within the VPC',
           Value: {
             Ref: 'LambdaExecutionSecurityGroup',
+          },
+        },
+        RDSSubnetGroup: {
+          Description: 'Subnet Group for rds',
+          Value: ['RDSSubnetGroup'],
+        },
+        RedshiftSubnetGroup: {
+          Description: 'Subnet Group for elasticache',
+          Value: ['RedshiftSubnetGroup'],
+        },
+        VPC: {
+          Description: 'VPC logical resource ID',
+          Value: {
+            Ref: 'VPC',
           },
         },
       };
@@ -26,11 +42,23 @@ describe('outputs', () => {
 
     it('builds the outputs with a bastion host', () => {
       const expected = {
-        VPC: {
-          Description: 'VPC logical resource ID',
+        BastionEIP: {
+          Description: 'Public IP of Bastion host',
           Value: {
-            Ref: 'VPC',
+            Ref: 'BastionEIP',
           },
+        },
+        BastionSSHUser: {
+          Description: 'SSH username for the Bastion host',
+          Value: 'ec2-user',
+        },
+        DAXSubnetGroup: {
+          Description: 'Subnet Group for dax',
+          Value: ['DAXSubnetGroup'],
+        },
+        ElastiCacheSubnetGroup: {
+          Description: 'Subnet Group for redshift',
+          Value: ['ElastiCacheSubnetGroup'],
         },
         LambdaExecutionSecurityGroupId: {
           Description:
@@ -39,14 +67,18 @@ describe('outputs', () => {
             Ref: 'LambdaExecutionSecurityGroup',
           },
         },
-        BastionSSHUser: {
-          Description: 'SSH username for the Bastion host',
-          Value: 'ec2-user',
+        RDSSubnetGroup: {
+          Description: 'Subnet Group for rds',
+          Value: ['RDSSubnetGroup'],
         },
-        BastionEIP: {
-          Description: 'Public IP of Bastion host',
+        RedshiftSubnetGroup: {
+          Description: 'Subnet Group for elasticache',
+          Value: ['RedshiftSubnetGroup'],
+        },
+        VPC: {
+          Description: 'VPC logical resource ID',
           Value: {
-            Ref: 'BastionEIP',
+            Ref: 'VPC',
           },
         },
       };

--- a/src/index.js
+++ b/src/index.js
@@ -242,7 +242,7 @@ class ServerlessVpcPlugin {
     }
 
     const outputs = providerObj.compiledCloudFormationTemplate.Outputs;
-    Object.assign(outputs, buildOutputs(createBastionHost));
+    Object.assign(outputs, buildOutputs(createBastionHost, subnetGroups));
 
     this.serverless.cli.log('Updating Lambda VPC configuration');
     const { vpc = {} } = providerObj;

--- a/src/outputs.js
+++ b/src/outputs.js
@@ -1,10 +1,13 @@
+const { VALID_SUBNET_GROUPS } = require('./constants');
+
 /**
  * Build CloudFormation Outputs on common resources
  *
  * @param {Boolean} createBastionHost
  * @return {Object}
  */
-function buildOutputs(createBastionHost = false) {
+
+function buildOutputs(createBastionHost = false, subnetGroups = VALID_SUBNET_GROUPS) {
   const outputs = {
     VPC: {
       Description: 'VPC logical resource ID',
@@ -32,6 +35,24 @@ function buildOutputs(createBastionHost = false) {
         Ref: 'BastionEIP',
       },
     };
+  }
+
+  if (subnetGroups) {
+    const typesToNames = {
+      rds: 'RDSSubnetGroup',
+      redshift: 'ElastiCacheSubnetGroup',
+      elasticache: 'RedshiftSubnetGroup',
+      dax: 'DAXSubnetGroup',
+    };
+
+    const subnetOutputs = subnetGroups.map(subnetGroup => ({
+      [typesToNames[subnetGroup]]: {
+        Description: `Subnet Group for ${subnetGroup}`,
+        Value: [typesToNames[subnetGroup]],
+      },
+    }));
+
+    Object.assign(outputs, ...subnetOutputs);
   }
 
   return outputs;


### PR DESCRIPTION
### Why?
 So that they may be consumed by other resources in the same stack. (or another stack: #89)

### Breaking changes?
Additional outputs added

### Usage?
See readme for more details.