### PR TITLE
fix: issue 147

### DIFF
--- a/src/vpc.js
+++ b/src/vpc.js
@@ -193,6 +193,7 @@ function buildRoute(
 ) {
   const route = {
     Type: 'AWS::EC2::Route',
+    DependsOn: ['InternetGatewayAttachment'],
     Properties: {
       DestinationCidrBlock: '0.0.0.0/0',
       RouteTableId: {


### PR DESCRIPTION
Resolves this error:

```
route table rtb-x and network gateway igw-x belong to different networks
```

Details in https://github.com/smoketurner/serverless-vpc-plugin/issues/147

Credit to @homes2001 for figuring out the root cause in #147  🍻 