### PR TITLE
Fix elasticache and rds output typo

### DIFF
--- a/__tests__/outputs.test.js
+++ b/__tests__/outputs.test.js
@@ -12,7 +12,7 @@ describe('outputs', () => {
           },
         },
         ElastiCacheSubnetGroup: {
-          Description: 'Subnet Group for redshift',
+          Description: 'Subnet Group for elasticache',
           Value: {
             Ref: 'ElastiCacheSubnetGroup',
           },
@@ -31,7 +31,7 @@ describe('outputs', () => {
           },
         },
         RedshiftSubnetGroup: {
-          Description: 'Subnet Group for elasticache',
+          Description: 'Subnet Group for redshift',
           Value: {
             Ref: 'RedshiftSubnetGroup',
           },
@@ -68,7 +68,7 @@ describe('outputs', () => {
           },
         },
         ElastiCacheSubnetGroup: {
-          Description: 'Subnet Group for redshift',
+          Description: 'Subnet Group for elasticache',
           Value: {
             Ref: 'ElastiCacheSubnetGroup',
           },
@@ -87,7 +87,7 @@ describe('outputs', () => {
           },
         },
         RedshiftSubnetGroup: {
-          Description: 'Subnet Group for elasticache',
+          Description: 'Subnet Group for redshift',
           Value: {
             Ref: 'RedshiftSubnetGroup',
           },
@@ -138,7 +138,7 @@ describe('outputs', () => {
           },
         },
         ElastiCacheSubnetGroup: {
-          Description: 'Subnet Group for redshift',
+          Description: 'Subnet Group for elasticache',
           Export: {
             Name: {
               'Fn::Join': [
@@ -196,7 +196,7 @@ describe('outputs', () => {
           },
         },
         RedshiftSubnetGroup: {
-          Description: 'Subnet Group for elasticache',
+          Description: 'Subnet Group for redshift',
           Export: {
             Name: {
               'Fn::Join': [

--- a/src/outputs.js
+++ b/src/outputs.js
@@ -22,8 +22,8 @@ function appendSubnetGroups(subnetGroups, outputs) {
   if (subnetGroups) {
     const typesToNames = {
       rds: 'RDSSubnetGroup',
-      redshift: 'ElastiCacheSubnetGroup',
-      elasticache: 'RedshiftSubnetGroup',
+      redshift: 'RedshiftSubnetGroup',
+      elasticache: 'ElastiCacheSubnetGroup',
       dax: 'DAXSubnetGroup',
     };
 


### PR DESCRIPTION
## Summary

It looks like RDS and Elasticache have been mixed up in the CloudFormation outputs. This doesn't matter too much when all of the subnet groups are enabled, as they will always be available regardless. However, when enabling only elasticache, the following error is thrown by CloudFormation as the Redshift group doesn't exist.

> Error: The CloudFormation template is invalid: Unresolved resource dependencies [RedshiftSubnetGroup] in the Outputs block of the template

## Solution

Swap them back around to the correct order and update tests.