### PR TITLE
Release 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin provisions the following resources:
 - `AWS::EC2::VPC`
 - `AWS::EC2::InternetGateway` (for outbound internet access from "Public" subnet)
 - `AWS::EC2::VPCGatewayAttachment` (to attach the `InternetGateway` to the VPC)
-- `AWS::EC2::SecurityGroup` (to execute Lambda functions [`LambdaExecutionSecurityGroup`])
+- `AWS::EC2::SecurityGroup` (to execute Lambda functions [`AppSecurityGroup`])
 
 If the VPC is allocated a /16 subnet, each availability zone within the region will be allocated a /20 subnet. Within each availability zone, this plugin will further divide the subnets:
 
@@ -99,6 +99,9 @@ custom:
     # Whether to create a NAT instance
     createNatInstance: false
 
+    # Whether to create AWS Systems Manager (SSM) Parameters
+    createParameters: false
+
     # Optionally specify AZs (defaults to auto-discover all availabile AZs)
     zones:
       - us-east-1a
@@ -117,8 +120,8 @@ custom:
     # for RDS, Redshift, ElasticCache and DAX will be provisioned.
     subnetGroups:
       - rds
-        
-    # Whether to export stack outputs so it may be consumed by other stacks 
+
+    # Whether to export stack outputs so it may be consumed by other stacks
     exportOutputs: false
 ```
 
@@ -127,16 +130,18 @@ custom:
 After executing `serverless deploy`, the following CloudFormation Stack Outputs will be provided:
 
 - `VPC`: VPC logical resource ID
-- `LambdaExecutionSecurityGroup`: Security Group logical resource ID that the Lambda functions use when executing within the VPC
+- `AppSecurityGroup`: Security Group ID that the applications use when executing within the VPC
+- `LambdaExecutionSecurityGroupId`: DEPRECATED - Please use AppSecurityGroupId instead
 - `BastionSSHUser`: SSH username to access the bastion host, if provisioned
 - `BastionEIP`: Elastic IP address associated to the bastion host, if provisioned
-- `RDSSubnetGroup`: SubnetGroup associated to RDS, if provisioned 
+- `RDSSubnetGroup`: SubnetGroup associated to RDS, if provisioned
 - `ElastiCacheSubnetGroup`: SubnetGroup associated to ElastiCache, if provisioned
 - `RedshiftSubnetGroup`: SubnetGroup associated to Redshift, if provisioned
 - `DAXSubnetGroup`: SubnetGroup associated to DAX, if provisioned
 - `AppSubnet{i}`: Each of the generated "Application" Subnets, where i is a 1 based index
 
 ### Exporting CloudFormation Outputs
+
 Setting `exportOutputs: true` will export stack outputs.  
 The name of the exported value will be prefixed by the cloud formation stack name (`AWS::StackName`).
-For example, the value of the `VPC` output of a stack named `foo-prod` will be exported as `foo-prod-VPC`. 
+For example, the value of the `VPC` output of a stack named `foo-prod` will be exported as `foo-prod-VPC`.

--- a/__tests__/az.test.js
+++ b/__tests__/az.test.js
@@ -3,9 +3,9 @@ const { splitSubnets } = require('../src/subnets');
 
 // fixtures
 const vpcSingleAZNatGWDB = require('./fixtures/vpc_single_az_natgw_db.json');
-const vpcSingleAZNoGatGWDB = require('./fixtures/vpc_single_az_no_natgw_db.json');
+const vpcSingleAZNoNatGWDB = require('./fixtures/vpc_single_az_no_natgw_db.json');
 const vpcSingleAZNatGWNoDB = require('./fixtures/vpc_single_az_natgw_no_db.json');
-const vpcSingleAZNoGatGWNoDB = require('./fixtures/vpc_single_az_no_natgw_no_db.json');
+const vpcSingleAZNoNatGWNoDB = require('./fixtures/vpc_single_az_no_natgw_no_db.json');
 
 const vpcMultipleAZNatGWDB = require('./fixtures/vpc_multiple_az_natgw_db.json');
 const vpcMultipleAZNoNatGWDB = require('./fixtures/vpc_multiple_az_no_natgw_db.json');
@@ -25,7 +25,7 @@ describe('az', () => {
     });
 
     it('builds a single AZ with a NAT Gateway and DBSubnet', () => {
-      const expected = Object.assign({}, vpcSingleAZNatGWDB);
+      const expected = { ...vpcSingleAZNatGWDB };
 
       const zones = ['us-east-1a'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -33,12 +33,13 @@ describe('az', () => {
         numNatGateway: 1,
         createDbSubnet: true,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds a single AZ without a NAT Gateway and DBSubnet', () => {
-      const expected = Object.assign({}, vpcSingleAZNoGatGWDB);
+      const expected = { ...vpcSingleAZNoNatGWDB };
 
       const zones = ['us-east-1a'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -46,12 +47,13 @@ describe('az', () => {
         numNatGateway: 0,
         createDbSubnet: true,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds a single AZ with a NAT Gateway and no DBSubnet', () => {
-      const expected = Object.assign({}, vpcSingleAZNatGWNoDB);
+      const expected = { ...vpcSingleAZNatGWNoDB };
 
       const zones = ['us-east-1a'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -59,12 +61,13 @@ describe('az', () => {
         numNatGateway: 1,
         createDbSubnet: false,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds a single AZ without a NAT Gateway and no DBSubnet', () => {
-      const expected = Object.assign({}, vpcSingleAZNoGatGWNoDB);
+      const expected = { ...vpcSingleAZNoNatGWNoDB };
 
       const zones = ['us-east-1a'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -72,12 +75,13 @@ describe('az', () => {
         numNatGateway: 0,
         createDbSubnet: false,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds multiple AZs with a NAT Gateway and DBSubnet', () => {
-      const expected = Object.assign({}, vpcMultipleAZNatGWDB);
+      const expected = { ...vpcMultipleAZNatGWDB };
 
       const zones = ['us-east-1a', 'us-east-1b'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -85,12 +89,13 @@ describe('az', () => {
         numNatGateway: 2,
         createDbSubnet: true,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds multiple AZs without a NAT Gateway and DBSubnet', () => {
-      const expected = Object.assign({}, vpcMultipleAZNoNatGWDB);
+      const expected = { ...vpcMultipleAZNoNatGWDB };
 
       const zones = ['us-east-1a', 'us-east-1b'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -98,12 +103,13 @@ describe('az', () => {
         numNatGateway: 0,
         createDbSubnet: true,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds multiple AZs with a NAT Gateway and no DBSubnet', () => {
-      const expected = Object.assign({}, vpcMultipleAZNatGWNoDB);
+      const expected = { ...vpcMultipleAZNatGWNoDB };
 
       const zones = ['us-east-1a', 'us-east-1b'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -111,12 +117,13 @@ describe('az', () => {
         numNatGateway: 2,
         createDbSubnet: false,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds multiple AZs without a NAT Gateway and no DBSubnet', () => {
-      const expected = Object.assign({}, vpcMultipleAZNoNatGWNoDB);
+      const expected = { ...vpcMultipleAZNoNatGWNoDB };
 
       const zones = ['us-east-1a', 'us-east-1b'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -124,12 +131,13 @@ describe('az', () => {
         numNatGateway: 0,
         createDbSubnet: false,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds multiple AZs with a single NAT Gateway and no DBSubnet', () => {
-      const expected = Object.assign({}, vpcMultipleAZSingleNatGWNoDB);
+      const expected = { ...vpcMultipleAZSingleNatGWNoDB };
 
       const zones = ['us-east-1a', 'us-east-1b'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -137,12 +145,13 @@ describe('az', () => {
         numNatGateway: 1,
         createDbSubnet: false,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
 
     it('builds multiple AZs with a multple NAT Gateways and no DBSubnet', () => {
-      const expected = Object.assign({}, vpcMultipleAZMultipleNatGWNoDB);
+      const expected = { ...vpcMultipleAZMultipleNatGWNoDB };
 
       const zones = ['us-east-1a', 'us-east-1b', 'us-east-1c'];
       const subnets = splitSubnets('10.0.0.0/16', zones);
@@ -150,6 +159,7 @@ describe('az', () => {
         numNatGateway: 2,
         createDbSubnet: false,
       });
+
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/__tests__/bastion.test.js
+++ b/__tests__/bastion.test.js
@@ -325,7 +325,7 @@ describe('bastion', () => {
 
   describe('#buildBastion', () => {
     it('builds the complete bastion host', async () => {
-      const scope = nock('http://checkip.amazonaws.com').get('/').reply(200, '127.0.0.1');
+      const scope = nock('https://checkip.amazonaws.com').get('/').reply(200, '127.0.0.1');
 
       const expected = {
         BastionEIP: {

--- a/__tests__/bastion.test.js
+++ b/__tests__/bastion.test.js
@@ -88,14 +88,14 @@ describe('bastion', () => {
             },
             SecurityGroupIngress: [
               {
-                Description: 'Allow inbound SSH access to the bastion host',
+                Description: 'permit inbound SSH',
                 IpProtocol: 'tcp',
                 FromPort: 22,
                 ToPort: 22,
                 CidrIp: '0.0.0.0/0',
               },
               {
-                Description: 'Allow inbound ICMP to the bastion host',
+                Description: 'permit inbound ICMP',
                 IpProtocol: 'icmp',
                 FromPort: -1,
                 ToPort: -1,
@@ -131,14 +131,14 @@ describe('bastion', () => {
             },
             SecurityGroupIngress: [
               {
-                Description: 'Allow inbound SSH access to the bastion host',
+                Description: 'permit inbound SSH',
                 IpProtocol: 'tcp',
                 FromPort: 22,
                 ToPort: 22,
                 CidrIp: '127.0.0.1/32',
               },
               {
-                Description: 'Allow inbound ICMP to the bastion host',
+                Description: 'permit inbound ICMP',
                 IpProtocol: 'icmp',
                 FromPort: -1,
                 ToPort: -1,
@@ -481,14 +481,14 @@ describe('bastion', () => {
             },
             SecurityGroupIngress: [
               {
-                Description: 'Allow inbound SSH access to the bastion host',
+                Description: 'permit inbound SSH',
                 IpProtocol: 'tcp',
                 FromPort: 22,
                 ToPort: 22,
                 CidrIp: '127.0.0.1/32',
               },
               {
-                Description: 'Allow inbound ICMP to the bastion host',
+                Description: 'permit inbound ICMP',
                 IpProtocol: 'icmp',
                 FromPort: -1,
                 ToPort: -1,

--- a/__tests__/bastion.test.js
+++ b/__tests__/bastion.test.js
@@ -12,13 +12,16 @@ const {
 } = require('../src/bastion');
 
 describe('bastion', () => {
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
   afterEach(() => {
     nock.cleanAll();
   });
 
   describe('#getPublicIp', () => {
     it('gets the public IP', async () => {
-      const scope = nock('http://checkip.amazonaws.com').get('/').reply(200, '127.0.0.1');
+      const scope = nock('https://checkip.amazonaws.com').get('/').reply(200, '127.0.0.1');
 
       const actual = await getPublicIp();
       expect(actual).toEqual('127.0.0.1');

--- a/__tests__/fixtures/vpc_multiple_az_multiple_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_multiple_natgw_no_db.json
@@ -9,7 +9,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP1", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP1",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
@@ -18,16 +21,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -42,7 +41,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP2", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP2",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet2"
@@ -51,16 +53,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -74,17 +72,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -102,17 +95,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -128,18 +116,6 @@
       }
     }
   },
-  "AppRoute1": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable1"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway1"
-      }
-    }
-  },
   "PublicSubnet1": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -149,17 +125,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -177,17 +148,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -205,7 +171,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -213,6 +178,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute1": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable1"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway1"
       }
     }
   },
@@ -225,17 +205,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -253,17 +228,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -279,18 +249,6 @@
       }
     }
   },
-  "AppRoute2": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable2"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway2"
-      }
-    }
-  },
   "PublicSubnet2": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -300,17 +258,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -328,17 +281,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -356,7 +304,6 @@
   },
   "PublicRoute2": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -364,6 +311,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute2": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable2"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway2"
       }
     }
   },
@@ -376,17 +338,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1c"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1c"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -404,17 +361,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1c"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet3.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -430,18 +382,6 @@
       }
     }
   },
-  "AppRoute3": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable3"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway1"
-      }
-    }
-  },
   "PublicSubnet3": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -451,17 +391,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1c"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1c"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -479,17 +414,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1c"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet3.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -507,7 +437,6 @@
   },
   "PublicRoute3": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -515,6 +444,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute3": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable3"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway1"
       }
     }
   }

--- a/__tests__/fixtures/vpc_multiple_az_natgw_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_natgw_db.json
@@ -9,7 +9,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP1", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP1",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
@@ -18,16 +21,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -42,7 +41,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP2", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP2",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet2"
@@ -51,16 +53,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -74,17 +72,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -102,17 +95,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -128,18 +116,6 @@
       }
     }
   },
-  "AppRoute1": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable1"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway1"
-      }
-    }
-  },
   "PublicSubnet1": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -149,17 +125,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -177,17 +148,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -205,7 +171,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -213,6 +178,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute1": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable1"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway1"
       }
     }
   },
@@ -225,17 +205,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -253,17 +228,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-${DBSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -288,17 +258,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -316,17 +281,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -342,18 +302,6 @@
       }
     }
   },
-  "AppRoute2": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable2"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway2"
-      }
-    }
-  },
   "PublicSubnet2": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -363,17 +311,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -391,17 +334,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -419,7 +357,6 @@
   },
   "PublicRoute2": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -427,6 +364,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute2": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable2"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway2"
       }
     }
   },
@@ -439,17 +391,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -467,17 +414,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-${DBSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }

--- a/__tests__/fixtures/vpc_multiple_az_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_natgw_no_db.json
@@ -9,7 +9,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP1", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP1",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
@@ -18,16 +21,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -42,7 +41,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP2", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP2",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet2"
@@ -51,16 +53,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -74,17 +72,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -102,17 +95,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -128,18 +116,6 @@
       }
     }
   },
-  "AppRoute1": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable1"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway1"
-      }
-    }
-  },
   "PublicSubnet1": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -149,17 +125,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -177,17 +148,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -205,7 +171,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -213,6 +178,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute1": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable1"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway1"
       }
     }
   },
@@ -225,17 +205,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -253,17 +228,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -279,18 +249,6 @@
       }
     }
   },
-  "AppRoute2": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable2"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway2"
-      }
-    }
-  },
   "PublicSubnet2": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -300,17 +258,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -328,17 +281,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -356,7 +304,6 @@
   },
   "PublicRoute2": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -364,6 +311,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute2": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable2"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway2"
       }
     }
   }

--- a/__tests__/fixtures/vpc_multiple_az_no_natgw_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_no_natgw_db.json
@@ -8,17 +8,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -36,17 +31,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -71,17 +61,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -99,17 +84,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -127,7 +107,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -136,7 +115,10 @@
       "GatewayId": {
         "Ref": "InternetGateway"
       }
-    }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
   },
   "DBSubnet1": {
     "Type": "AWS::EC2::Subnet",
@@ -147,17 +129,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -175,17 +152,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-${DBSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -210,17 +182,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -238,17 +205,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -273,17 +235,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -301,17 +258,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -329,7 +281,6 @@
   },
   "PublicRoute2": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -338,7 +289,10 @@
       "GatewayId": {
         "Ref": "InternetGateway"
       }
-    }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
   },
   "DBSubnet2": {
     "Type": "AWS::EC2::Subnet",
@@ -349,17 +303,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -377,17 +326,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-${DBSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }

--- a/__tests__/fixtures/vpc_multiple_az_no_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_no_natgw_no_db.json
@@ -8,17 +8,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -36,17 +31,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -71,17 +61,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -99,17 +84,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -127,7 +107,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -136,7 +115,10 @@
       "GatewayId": {
         "Ref": "InternetGateway"
       }
-    }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
   },
   "AppSubnet2": {
     "Type": "AWS::EC2::Subnet",
@@ -147,17 +129,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -175,17 +152,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -210,17 +182,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -238,17 +205,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -266,7 +228,6 @@
   },
   "PublicRoute2": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -275,6 +236,9 @@
       "GatewayId": {
         "Ref": "InternetGateway"
       }
-    }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
   }
 }

--- a/__tests__/fixtures/vpc_multiple_az_single_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_multiple_az_single_natgw_no_db.json
@@ -9,7 +9,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP1", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP1",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
@@ -18,16 +21,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -41,17 +40,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -69,17 +63,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -95,18 +84,6 @@
       }
     }
   },
-  "AppRoute1": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable1"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway1"
-      }
-    }
-  },
   "PublicSubnet1": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -116,17 +93,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -144,17 +116,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -172,7 +139,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -180,6 +146,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute1": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable1"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway1"
       }
     }
   },
@@ -192,17 +173,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -220,17 +196,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -246,18 +217,6 @@
       }
     }
   },
-  "AppRoute2": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable2"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway1"
-      }
-    }
-  },
   "PublicSubnet2": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -267,17 +226,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1b"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -295,17 +249,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1b"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet2.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -323,7 +272,6 @@
   },
   "PublicRoute2": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -331,6 +279,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute2": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable2"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway1"
       }
     }
   }

--- a/__tests__/fixtures/vpc_single_az_natgw_db.json
+++ b/__tests__/fixtures/vpc_single_az_natgw_db.json
@@ -9,7 +9,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP1", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP1",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
@@ -18,16 +21,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -41,17 +40,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -69,17 +63,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -95,18 +84,6 @@
       }
     }
   },
-  "AppRoute1": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable1"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway1"
-      }
-    }
-  },
   "PublicSubnet1": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -116,17 +93,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -144,17 +116,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -172,7 +139,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -180,6 +146,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute1": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable1"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway1"
       }
     }
   },
@@ -192,17 +173,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -220,17 +196,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-${DBSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }

--- a/__tests__/fixtures/vpc_single_az_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_single_az_natgw_no_db.json
@@ -9,7 +9,10 @@
     "Type": "AWS::EC2::NatGateway",
     "Properties": {
       "AllocationId": {
-        "Fn::GetAtt": ["EIP1", "AllocationId"]
+        "Fn::GetAtt": [
+          "EIP1",
+          "AllocationId"
+        ]
       },
       "SubnetId": {
         "Ref": "PublicSubnet1"
@@ -18,16 +21,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -41,17 +40,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -69,17 +63,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -95,18 +84,6 @@
       }
     }
   },
-  "AppRoute1": {
-    "Type": "AWS::EC2::Route",
-    "Properties": {
-      "DestinationCidrBlock": "0.0.0.0/0",
-      "RouteTableId": {
-        "Ref": "AppRouteTable1"
-      },
-      "NatGatewayId": {
-        "Ref": "NatGateway1"
-      }
-    }
-  },
   "PublicSubnet1": {
     "Type": "AWS::EC2::Subnet",
     "Properties": {
@@ -116,17 +93,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -144,17 +116,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -172,7 +139,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -180,6 +146,21 @@
       },
       "GatewayId": {
         "Ref": "InternetGateway"
+      }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
+  },
+  "AppRoute1": {
+    "Type": "AWS::EC2::Route",
+    "Properties": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "RouteTableId": {
+        "Ref": "AppRouteTable1"
+      },
+      "NatGatewayId": {
+        "Ref": "NatGateway1"
       }
     }
   }

--- a/__tests__/fixtures/vpc_single_az_no_natgw_db.json
+++ b/__tests__/fixtures/vpc_single_az_no_natgw_db.json
@@ -8,17 +8,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -36,17 +31,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -71,17 +61,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -99,17 +84,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -127,7 +107,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -136,7 +115,10 @@
       "GatewayId": {
         "Ref": "InternetGateway"
       }
-    }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
   },
   "DBSubnet1": {
     "Type": "AWS::EC2::Subnet",
@@ -147,17 +129,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -175,17 +152,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "db",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-db-${DBSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }

--- a/__tests__/fixtures/vpc_single_az_no_natgw_no_db.json
+++ b/__tests__/fixtures/vpc_single_az_no_natgw_no_db.json
@@ -8,17 +8,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ],
       "VpcId": {
@@ -36,17 +31,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "app",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Private"
         }
       ]
     }
@@ -71,17 +61,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-us-east-1a"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ],
       "VpcId": {
@@ -99,17 +84,12 @@
         {
           "Key": "Name",
           "Value": {
-            "Fn::Join": [
-              "-",
-              [
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "public",
-                "us-east-1a"
-              ]
-            ]
+            "Fn::Sub": "${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}"
           }
+        },
+        {
+          "Key": "Network",
+          "Value": "Public"
         }
       ]
     }
@@ -127,7 +107,6 @@
   },
   "PublicRoute1": {
     "Type": "AWS::EC2::Route",
-    "DependsOn": ["InternetGatewayAttachment"],
     "Properties": {
       "DestinationCidrBlock": "0.0.0.0/0",
       "RouteTableId": {
@@ -136,6 +115,9 @@
       "GatewayId": {
         "Ref": "InternetGateway"
       }
-    }
+    },
+    "DependsOn": [
+      "InternetGatewayAttachment"
+    ]
   }
 }

--- a/__tests__/flow_logs.test.js
+++ b/__tests__/flow_logs.test.js
@@ -85,6 +85,7 @@ describe('flow_logs', () => {
         LogBucket: {
           Type: 'AWS::S3::Bucket',
           DeletionPolicy: 'Retain',
+          UpdateReplacePolicy: 'Retain',
           Properties: {
             AccessControl: 'LogDeliveryWrite',
             BucketEncryption: {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk-mock');
+const nock = require('nock');
 
 const Serverless = require('serverless');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
@@ -9,6 +10,8 @@ describe('ServerlessVpcPlugin', () => {
   let plugin;
 
   beforeEach(() => {
+    nock.disableNetConnect();
+
     const options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/__tests__/nacl.test.js
+++ b/__tests__/nacl.test.js
@@ -18,15 +18,8 @@ describe('nacl', () => {
               {
                 Key: 'Name',
                 Value: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      {
-                        Ref: 'AWS::StackName',
-                      },
-                      'app',
-                    ],
-                  ],
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-app',
                 },
               },
             ],
@@ -115,15 +108,8 @@ describe('nacl', () => {
               {
                 Key: 'Name',
                 Value: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      {
-                        Ref: 'AWS::StackName',
-                      },
-                      'public',
-                    ],
-                  ],
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-public',
                 },
               },
             ],
@@ -208,15 +194,8 @@ describe('nacl', () => {
               {
                 Key: 'Name',
                 Value: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      {
-                        Ref: 'AWS::StackName',
-                      },
-                      'app',
-                    ],
-                  ],
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-app',
                 },
               },
             ],
@@ -301,15 +280,8 @@ describe('nacl', () => {
               {
                 Key: 'Name',
                 Value: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      {
-                        Ref: 'AWS::StackName',
-                      },
-                      'db',
-                    ],
-                  ],
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-db',
                 },
               },
             ],

--- a/__tests__/nat_instance.test.js
+++ b/__tests__/nat_instance.test.js
@@ -13,14 +13,14 @@ describe('nat_instance', () => {
             },
             SecurityGroupEgress: [
               {
-                Description: 'Allow outbound HTTP access to the Internet',
+                Description: 'permit outbound HTTP to the Internet',
                 IpProtocol: 'tcp',
                 FromPort: 80,
                 ToPort: 80,
                 CidrIp: '0.0.0.0/0',
               },
               {
-                Description: 'Allow outbound HTTPS access to the Internet',
+                Description: 'permit outbound HTTPS to the Internet',
                 IpProtocol: 'tcp',
                 FromPort: 443,
                 ToPort: 443,
@@ -29,32 +29,22 @@ describe('nat_instance', () => {
             ],
             SecurityGroupIngress: [
               {
-                Description: 'Allow inbound HTTP traffic from AppSubnet1',
+                Description: 'permit inbound HTTP from AppSecurityGroup',
                 IpProtocol: 'tcp',
                 FromPort: 80,
                 ToPort: 80,
-                CidrIp: '10.0.0.0/21',
+                SourceSecurityGroupId: {
+                  Ref: 'AppSecurityGroup',
+                },
               },
               {
-                Description: 'Allow inbound HTTPS traffic from AppSubnet1',
+                Description: 'permit inbound HTTPS from AppSecurityGroup',
                 IpProtocol: 'tcp',
                 FromPort: 443,
                 ToPort: 443,
-                CidrIp: '10.0.0.0/21',
-              },
-              {
-                Description: 'Allow inbound HTTP traffic from AppSubnet2',
-                IpProtocol: 'tcp',
-                FromPort: 80,
-                ToPort: 80,
-                CidrIp: '10.0.6.0/21',
-              },
-              {
-                Description: 'Allow inbound HTTPS traffic from AppSubnet2',
-                IpProtocol: 'tcp',
-                FromPort: 443,
-                ToPort: 443,
-                CidrIp: '10.0.6.0/21',
+                SourceSecurityGroupId: {
+                  Ref: 'AppSecurityGroup',
+                },
               },
             ],
             Tags: [
@@ -70,7 +60,7 @@ describe('nat_instance', () => {
         },
       };
 
-      const actual = buildNatSecurityGroup(['10.0.0.0/21', '10.0.6.0/21']);
+      const actual = buildNatSecurityGroup();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/__tests__/natgw.test.js
+++ b/__tests__/natgw.test.js
@@ -33,16 +33,13 @@ describe('natgw', () => {
               {
                 Key: 'Name',
                 Value: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      {
-                        Ref: 'AWS::StackName',
-                      },
-                      'us-east-1a',
-                    ],
-                  ],
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-us-east-1a',
                 },
+              },
+              {
+                Key: 'Network',
+                Value: 'Public',
               },
             ],
           },

--- a/__tests__/outputs.test.js
+++ b/__tests__/outputs.test.js
@@ -35,10 +35,15 @@ describe('outputs', () => {
           },
         },
         LambdaExecutionSecurityGroupId: {
-          Description:
-            'Security Group logical resource ID that the Lambda functions use when executing within the VPC',
+          Description: 'DEPRECATED - Please use AppSecurityGroupId instead',
           Value: {
-            Ref: 'LambdaExecutionSecurityGroup',
+            Ref: 'AppSecurityGroup',
+          },
+        },
+        AppSecurityGroupId: {
+          Description: 'Security Group ID that the applications use when executing within the VPC',
+          Value: {
+            Ref: 'AppSecurityGroup',
           },
         },
         RDSSubnetGroup: {
@@ -109,10 +114,15 @@ describe('outputs', () => {
           },
         },
         LambdaExecutionSecurityGroupId: {
-          Description:
-            'Security Group logical resource ID that the Lambda functions use when executing within the VPC',
+          Description: 'DEPRECATED - Please use AppSecurityGroupId instead',
           Value: {
-            Ref: 'LambdaExecutionSecurityGroup',
+            Ref: 'AppSecurityGroup',
+          },
+        },
+        AppSecurityGroupId: {
+          Description: 'Security Group ID that the applications use when executing within the VPC',
+          Value: {
+            Ref: 'AppSecurityGroup',
           },
         },
         RDSSubnetGroup: {
@@ -173,7 +183,8 @@ describe('outputs', () => {
         AppSubnet1: {
           Export: {
             Name: {
-              'Fn::Join': ['-', [{ Ref: 'AWS::StackName' }, 'AppSubnet1']],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-AppSubnet1',
             },
           },
           Value: {
@@ -183,7 +194,8 @@ describe('outputs', () => {
         AppSubnet2: {
           Export: {
             Name: {
-              'Fn::Join': ['-', [{ Ref: 'AWS::StackName' }, 'AppSubnet2']],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-AppSubnet2',
             },
           },
           Value: {
@@ -193,7 +205,8 @@ describe('outputs', () => {
         AppSubnet3: {
           Export: {
             Name: {
-              'Fn::Join': ['-', [{ Ref: 'AWS::StackName' }, 'AppSubnet3']],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-AppSubnet3',
             },
           },
           Value: {
@@ -204,15 +217,8 @@ describe('outputs', () => {
           Description: 'Subnet Group for dax',
           Export: {
             Name: {
-              'Fn::Join': [
-                '-',
-                [
-                  {
-                    Ref: 'AWS::StackName',
-                  },
-                  'DAXSubnetGroup',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-DAXSubnetGroup',
             },
           },
           Value: {
@@ -223,15 +229,8 @@ describe('outputs', () => {
           Description: 'Subnet Group for elasticache',
           Export: {
             Name: {
-              'Fn::Join': [
-                '-',
-                [
-                  {
-                    Ref: 'AWS::StackName',
-                  },
-                  'ElastiCacheSubnetGroup',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-ElastiCacheSubnetGroup',
             },
           },
           Value: {
@@ -239,38 +238,35 @@ describe('outputs', () => {
           },
         },
         LambdaExecutionSecurityGroupId: {
-          Description:
-            'Security Group logical resource ID that the Lambda functions use when executing within the VPC',
+          Description: 'DEPRECATED - Please use AppSecurityGroupId instead',
           Export: {
             Name: {
-              'Fn::Join': [
-                '-',
-                [
-                  {
-                    Ref: 'AWS::StackName',
-                  },
-                  'LambdaExecutionSecurityGroupId',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-LambdaExecutionSecurityGroupId',
             },
           },
           Value: {
-            Ref: 'LambdaExecutionSecurityGroup',
+            Ref: 'AppSecurityGroup',
+          },
+        },
+        AppSecurityGroupId: {
+          Description: 'Security Group ID that the applications use when executing within the VPC',
+          Export: {
+            Name: {
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-AppSecurityGroupId',
+            },
+          },
+          Value: {
+            Ref: 'AppSecurityGroup',
           },
         },
         RDSSubnetGroup: {
           Description: 'Subnet Group for rds',
           Export: {
             Name: {
-              'Fn::Join': [
-                '-',
-                [
-                  {
-                    Ref: 'AWS::StackName',
-                  },
-                  'RDSSubnetGroup',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-RDSSubnetGroup',
             },
           },
           Value: {
@@ -281,15 +277,8 @@ describe('outputs', () => {
           Description: 'Subnet Group for redshift',
           Export: {
             Name: {
-              'Fn::Join': [
-                '-',
-                [
-                  {
-                    Ref: 'AWS::StackName',
-                  },
-                  'RedshiftSubnetGroup',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-RedshiftSubnetGroup',
             },
           },
           Value: {
@@ -300,15 +289,8 @@ describe('outputs', () => {
           Description: 'VPC logical resource ID',
           Export: {
             Name: {
-              'Fn::Join': [
-                '-',
-                [
-                  {
-                    Ref: 'AWS::StackName',
-                  },
-                  'VPC',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-VPC',
             },
           },
           Value: {
@@ -335,15 +317,19 @@ describe('outputs', () => {
           },
         },
         LambdaExecutionSecurityGroupId: {
-          Description:
-            'Security Group logical resource ID that the Lambda functions use when executing within the VPC',
+          Description: 'DEPRECATED - Please use AppSecurityGroupId instead',
           Value: {
-            Ref: 'LambdaExecutionSecurityGroup',
+            Ref: 'AppSecurityGroup',
+          },
+        },
+        AppSecurityGroupId: {
+          Description: 'Security Group ID that the applications use when executing within the VPC',
+          Value: {
+            Ref: 'AppSecurityGroup',
           },
         },
         VPC: {
           Description: 'VPC logical resource ID',
-
           Value: {
             Ref: 'VPC',
           },

--- a/__tests__/parameters.test.js
+++ b/__tests__/parameters.test.js
@@ -1,0 +1,51 @@
+const { buildParameter } = require('../src/parameters');
+
+describe('parameters', () => {
+  describe('#buildParameter', () => {
+    it('builds an SSM String parameter', () => {
+      const expected = {
+        ParameterVPC: {
+          Type: 'AWS::SSM::Parameter',
+          Properties: {
+            Name: {
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '/SLS/${AWS::StackName}/VPC',
+            },
+            Tier: 'Standard',
+            Type: 'String',
+            Value: {
+              Ref: 'VPC',
+            },
+          },
+        },
+      };
+
+      const actual = buildParameter('VPC');
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+
+    it('builds an SSM StringList parameter', () => {
+      const expected = {
+        ParameterAppSubnets: {
+          Type: 'AWS::SSM::Parameter',
+          Properties: {
+            Name: {
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '/SLS/${AWS::StackName}/AppSubnets',
+            },
+            Tier: 'Standard',
+            Type: 'StringList',
+            Value: {
+              'Fn::Join': [',', [{ Ref: 'sg-1' }, { Ref: 'sg-2' }]],
+            },
+          },
+        },
+      };
+
+      const actual = buildParameter('AppSubnets', { Value: [{ Ref: 'sg-1' }, { Ref: 'sg-2' }] });
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+});

--- a/__tests__/routes.test.js
+++ b/__tests__/routes.test.js
@@ -1,0 +1,162 @@
+const { buildRoute, buildRouteTable, buildRouteTableAssociation } = require('../src/routes');
+
+describe('routes', () => {
+  describe('#buildRouteTable', () => {
+    it('builds a private route table', () => {
+      const expected = {
+        AppRouteTable1: {
+          Type: 'AWS::EC2::RouteTable',
+          Properties: {
+            VpcId: {
+              Ref: 'VPC',
+            },
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-app-${AppSubnet1.AvailabilityZone}',
+                },
+              },
+              {
+                Key: 'Network',
+                Value: 'Private',
+              },
+            ],
+          },
+        },
+      };
+      const actual = buildRouteTable('App', 1);
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+
+    it('builds a public route table', () => {
+      const expected = {
+        PublicRouteTable1: {
+          Type: 'AWS::EC2::RouteTable',
+          Properties: {
+            VpcId: {
+              Ref: 'VPC',
+            },
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-public-${PublicSubnet1.AvailabilityZone}',
+                },
+              },
+              {
+                Key: 'Network',
+                Value: 'Public',
+              },
+            ],
+          },
+        },
+      };
+      const actual = buildRouteTable('Public', 1);
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
+  describe('#buildRouteTableAssociation', () => {
+    it('builds a route table association', () => {
+      const expected = {
+        AppRouteTableAssociation1: {
+          Type: 'AWS::EC2::SubnetRouteTableAssociation',
+          Properties: {
+            RouteTableId: {
+              Ref: 'AppRouteTable1',
+            },
+            SubnetId: {
+              Ref: 'AppSubnet1',
+            },
+          },
+        },
+      };
+      const actual = buildRouteTableAssociation('App', 1);
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
+  describe('#buildRoute', () => {
+    it('builds a route with a NAT Gateway', () => {
+      const expected = {
+        AppRoute1: {
+          Type: 'AWS::EC2::Route',
+          Properties: {
+            DestinationCidrBlock: '0.0.0.0/0',
+            NatGatewayId: {
+              Ref: 'NatGateway1',
+            },
+            RouteTableId: {
+              Ref: 'AppRouteTable1',
+            },
+          },
+        },
+      };
+      const actual = buildRoute('App', 1, {
+        NatGatewayId: 'NatGateway1',
+      });
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+
+    it('builds a route with an Internet Gateway', () => {
+      const expected = {
+        PublicRoute1: {
+          Type: 'AWS::EC2::Route',
+          DependsOn: ['InternetGatewayAttachment'],
+          Properties: {
+            DestinationCidrBlock: '0.0.0.0/0',
+            GatewayId: {
+              Ref: 'InternetGateway',
+            },
+            RouteTableId: {
+              Ref: 'PublicRouteTable1',
+            },
+          },
+        },
+      };
+      const actual = buildRoute('Public', 1, {
+        GatewayId: 'InternetGateway',
+      });
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+
+    it('builds a route with an Instance Gateway', () => {
+      const expected = {
+        AppRoute1: {
+          Type: 'AWS::EC2::Route',
+          Properties: {
+            DestinationCidrBlock: '0.0.0.0/0',
+            InstanceId: {
+              Ref: 'BastionInstance',
+            },
+            RouteTableId: {
+              Ref: 'AppRouteTable1',
+            },
+          },
+        },
+      };
+      const actual = buildRoute('App', 1, {
+        InstanceId: 'BastionInstance',
+      });
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+
+    it('throws an error if no gateway provided', () => {
+      expect(() => {
+        buildRoute('App', 1);
+      }).toThrow(
+        'Unable to create route: either NatGatewayId, GatewayId or InstanceId must be provided',
+      );
+      expect.assertions(1);
+    });
+  });
+});

--- a/__tests__/subnet_groups.test.js
+++ b/__tests__/subnet_groups.test.js
@@ -40,35 +40,6 @@ describe('subnet_groups', () => {
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
-
-    it('builds an RDS subnet group with a custom name', () => {
-      const expected = {
-        MyRDSSubnetGroup: {
-          Type: 'AWS::RDS::DBSubnetGroup',
-          Properties: {
-            DBSubnetGroupName: {
-              Ref: 'AWS::StackName',
-            },
-            DBSubnetGroupDescription: {
-              Ref: 'AWS::StackName',
-            },
-            SubnetIds: [
-              {
-                Ref: 'DBSubnet1',
-              },
-              {
-                Ref: 'DBSubnet2',
-              },
-            ],
-          },
-        },
-      };
-      const actual = buildRDSSubnetGroup(2, {
-        name: 'MyRDSSubnetGroup',
-      });
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
   });
 
   describe('#buildElastiCacheSubnetGroup', () => {
@@ -104,35 +75,6 @@ describe('subnet_groups', () => {
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
-
-    it('builds an ElastiCache subnet group with a custom name', () => {
-      const expected = {
-        MyElastiCacheSubnetGroup: {
-          Type: 'AWS::ElastiCache::SubnetGroup',
-          Properties: {
-            CacheSubnetGroupName: {
-              Ref: 'AWS::StackName',
-            },
-            Description: {
-              Ref: 'AWS::StackName',
-            },
-            SubnetIds: [
-              {
-                Ref: 'DBSubnet1',
-              },
-              {
-                Ref: 'DBSubnet2',
-              },
-            ],
-          },
-        },
-      };
-      const actual = buildElastiCacheSubnetGroup(2, {
-        name: 'MyElastiCacheSubnetGroup',
-      });
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
   });
 
   describe('#buildRedshiftSubnetGroup', () => {
@@ -162,32 +104,6 @@ describe('subnet_groups', () => {
         },
       };
       const actual = buildRedshiftSubnetGroup(2);
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-
-    it('builds an Redshift subnet group with a custom name', () => {
-      const expected = {
-        MyRedshiftSubnetGroup: {
-          Type: 'AWS::Redshift::ClusterSubnetGroup',
-          Properties: {
-            Description: {
-              Ref: 'AWS::StackName',
-            },
-            SubnetIds: [
-              {
-                Ref: 'DBSubnet1',
-              },
-              {
-                Ref: 'DBSubnet2',
-              },
-            ],
-          },
-        },
-      };
-      const actual = buildRedshiftSubnetGroup(2, {
-        name: 'MyRedshiftSubnetGroup',
-      });
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -223,35 +139,6 @@ describe('subnet_groups', () => {
         },
       };
       const actual = buildDAXSubnetGroup(2);
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-
-    it('builds an DAX subnet group with a custom name', () => {
-      const expected = {
-        MyDAXSubnetGroup: {
-          Type: 'AWS::DAX::SubnetGroup',
-          Properties: {
-            SubnetGroupName: {
-              Ref: 'AWS::StackName',
-            },
-            Description: {
-              Ref: 'AWS::StackName',
-            },
-            SubnetIds: [
-              {
-                Ref: 'DBSubnet1',
-              },
-              {
-                Ref: 'DBSubnet2',
-              },
-            ],
-          },
-        },
-      };
-      const actual = buildDAXSubnetGroup(2, {
-        name: 'MyDAXSubnetGroup',
-      });
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/__tests__/vpc.test.js
+++ b/__tests__/vpc.test.js
@@ -127,6 +127,27 @@ describe('vpc', () => {
                 ToPort: 443,
                 CidrIp: '0.0.0.0/0',
               },
+              {
+                DestinationPrefixListId: 'pl-63a5400a',
+                Description: 'permit HTTPS to S3',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+              },
+              {
+                DestinationPrefixListId: 'pl-63a5400a',
+                Description: 'permit HTTP to S3',
+                IpProtocol: 'tcp',
+                FromPort: 80,
+                ToPort: 80,
+              },
+              {
+                DestinationPrefixListId: 'pl-02cd2c6b',
+                Description: 'permit HTTPS to DynamoDB',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+              },
             ],
             SecurityGroupIngress: [
               {
@@ -152,7 +173,12 @@ describe('vpc', () => {
           },
         },
       };
-      const actual = buildAppSecurityGroup();
+
+      const prefixLists = {
+        s3: 'pl-63a5400a',
+        dynamodb: 'pl-02cd2c6b',
+      };
+      const actual = buildAppSecurityGroup(prefixLists);
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -171,7 +197,7 @@ describe('vpc', () => {
                 Key: 'Name',
                 Value: {
                   // eslint-disable-next-line no-template-curly-in-string
-                  'Fn:Sub': '${AWS::StackName}-DHCPOptionsSet',
+                  'Fn::Sub': '${AWS::StackName}-DHCPOptionsSet',
                 },
               },
             ],
@@ -209,7 +235,7 @@ describe('vpc', () => {
                 Key: 'Name',
                 Value: {
                   // eslint-disable-next-line no-template-curly-in-string
-                  'Fn:Sub': '${AWS::StackName}-DHCPOptionsSet',
+                  'Fn::Sub': '${AWS::StackName}-DHCPOptionsSet',
                 },
               },
             ],

--- a/__tests__/vpc.test.js
+++ b/__tests__/vpc.test.js
@@ -1,17 +1,13 @@
 const {
   buildVpc,
   buildInternetGateway,
-  buildInternetGatewayAttachment,
-  buildLambdaSecurityGroup,
-  buildSubnet,
-  buildRoute,
-  buildRouteTable,
-  buildRouteTableAssociation,
+  buildAppSecurityGroup,
+  buildDHCPOptions,
 } = require('../src/vpc');
 
 describe('vpc', () => {
   describe('#buildVpc', () => {
-    it('builds a VPC with default name', () => {
+    it('builds a VPC', () => {
       const expected = {
         VPC: {
           Type: 'AWS::EC2::VPC',
@@ -39,7 +35,7 @@ describe('vpc', () => {
 
     it('builds a VPC with a custom parameters', () => {
       const expected = {
-        MyVpc: {
+        VPC: {
           Type: 'AWS::EC2::VPC',
           Properties: {
             CidrBlock: '192.168.0.0/16',
@@ -58,9 +54,7 @@ describe('vpc', () => {
         },
       };
 
-      const actual = buildVpc('192.168.0.0/16', {
-        name: 'MyVpc',
-      });
+      const actual = buildVpc('192.168.0.0/16');
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -76,45 +70,17 @@ describe('vpc', () => {
               {
                 Key: 'Name',
                 Value: {
-                  Ref: 'AWS::StackName',
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-igw',
                 },
               },
-            ],
-          },
-        },
-      };
-
-      const actual = buildInternetGateway();
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-
-    it('builds an Internet Gateway with a custom name', () => {
-      const expected = {
-        MyInternetGateway: {
-          Type: 'AWS::EC2::InternetGateway',
-          Properties: {
-            Tags: [
               {
-                Key: 'Name',
-                Value: {
-                  Ref: 'AWS::StackName',
-                },
+                Key: 'Network',
+                Value: 'Public',
               },
             ],
           },
         },
-      };
-
-      const actual = buildInternetGateway({ name: 'MyInternetGateway' });
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-  });
-
-  describe('#buildInternetGatewayAttachment', () => {
-    it('builds an Internet Gateway Attachment with default name', () => {
-      const expected = {
         InternetGatewayAttachment: {
           Type: 'AWS::EC2::VPCGatewayAttachment',
           Properties: {
@@ -128,212 +94,49 @@ describe('vpc', () => {
         },
       };
 
-      const actual = buildInternetGatewayAttachment();
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-
-    it('builds an Internet Gateway Attachment with a custom name', () => {
-      const expected = {
-        MyInternetGatewayAttachment: {
-          Type: 'AWS::EC2::VPCGatewayAttachment',
-          Properties: {
-            InternetGatewayId: {
-              Ref: 'InternetGateway',
-            },
-            VpcId: {
-              Ref: 'VPC',
-            },
-          },
-        },
-      };
-
-      const actual = buildInternetGatewayAttachment({
-        name: 'MyInternetGatewayAttachment',
-      });
-
+      const actual = buildInternetGateway();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
   });
 
-  describe('#buildSubnet', () => {
-    it('builds a subnet', () => {
+  describe('#buildAppSecurityGroup', () => {
+    it('builds a security group with no options', () => {
       const expected = {
-        AppSubnet1: {
-          Type: 'AWS::EC2::Subnet',
+        DefaultSecurityGroupEgress: {
+          Type: 'AWS::EC2::SecurityGroupEgress',
           Properties: {
-            AvailabilityZone: 'us-east-1a',
-            CidrBlock: '10.0.0.0/22',
-            Tags: [
-              {
-                Key: 'Name',
-                Value: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      {
-                        Ref: 'AWS::StackName',
-                      },
-                      'app',
-                      'us-east-1a',
-                    ],
-                  ],
-                },
-              },
-            ],
-            VpcId: {
-              Ref: 'VPC',
+            IpProtocol: '-1',
+            DestinationSecurityGroupId: {
+              'Fn::GetAtt': ['VPC', 'DefaultSecurityGroup'],
+            },
+            GroupId: {
+              'Fn::GetAtt': ['VPC', 'DefaultSecurityGroup'],
             },
           },
         },
-      };
-      const actual = buildSubnet('App', 1, 'us-east-1a', '10.0.0.0/22');
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-  });
-
-  describe('#buildRouteTable', () => {
-    it('builds a route table', () => {
-      const expected = {
-        AppRouteTable1: {
-          Type: 'AWS::EC2::RouteTable',
-          Properties: {
-            VpcId: {
-              Ref: 'VPC',
-            },
-            Tags: [
-              {
-                Key: 'Name',
-                Value: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      {
-                        Ref: 'AWS::StackName',
-                      },
-                      'app',
-                      'us-east-1a',
-                    ],
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      };
-      const actual = buildRouteTable('App', 1, 'us-east-1a');
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-  });
-
-  describe('#buildRouteTableAssociation', () => {
-    it('builds a route table association', () => {
-      const expected = {
-        AppRouteTableAssociation1: {
-          Type: 'AWS::EC2::SubnetRouteTableAssociation',
-          Properties: {
-            RouteTableId: {
-              Ref: 'AppRouteTable1',
-            },
-            SubnetId: {
-              Ref: 'AppSubnet1',
-            },
-          },
-        },
-      };
-      const actual = buildRouteTableAssociation('App', 1);
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-  });
-
-  describe('#buildRoute', () => {
-    it('builds a route with a NAT Gateway', () => {
-      const expected = {
-        AppRoute1: {
-          Type: 'AWS::EC2::Route',
-          Properties: {
-            DestinationCidrBlock: '0.0.0.0/0',
-            NatGatewayId: {
-              Ref: 'NatGateway1',
-            },
-            RouteTableId: {
-              Ref: 'AppRouteTable1',
-            },
-          },
-        },
-      };
-      const actual = buildRoute('App', 1, {
-        NatGatewayId: 'NatGateway1',
-      });
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-
-    it('builds a route with an Internet Gateway', () => {
-      const expected = {
-        AppRoute1: {
-          Type: 'AWS::EC2::Route',
-          Properties: {
-            DestinationCidrBlock: '0.0.0.0/0',
-            GatewayId: {
-              Ref: 'InternetGateway',
-            },
-            RouteTableId: {
-              Ref: 'AppRouteTable1',
-            },
-          },
-        },
-      };
-      const actual = buildRoute('App', 1, {
-        GatewayId: 'InternetGateway',
-      });
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-
-    it('builds a route with an Instance Gateway', () => {
-      const expected = {
-        AppRoute1: {
-          Type: 'AWS::EC2::Route',
-          Properties: {
-            DestinationCidrBlock: '0.0.0.0/0',
-            InstanceId: {
-              Ref: 'BastionInstance',
-            },
-            RouteTableId: {
-              Ref: 'AppRouteTable1',
-            },
-          },
-        },
-      };
-      const actual = buildRoute('App', 1, {
-        InstanceId: 'BastionInstance',
-      });
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-
-    it('throws an error if no gateway provided', () => {
-      expect(() => {
-        buildRoute('App', 1);
-      }).toThrow(
-        'Unable to create route: either NatGatewayId, GatewayId or InstanceId must be provided',
-      );
-      expect.assertions(1);
-    });
-  });
-
-  describe('#buildLambdaSecurityGroup', () => {
-    it('builds a Lambda security group with no options', () => {
-      const expected = {
-        LambdaExecutionSecurityGroup: {
+        AppSecurityGroup: {
           Type: 'AWS::EC2::SecurityGroup',
           Properties: {
-            GroupDescription: 'Lambda Execution Group',
+            GroupDescription: 'Application Security Group',
+            SecurityGroupEgress: [
+              {
+                Description: 'permit HTTPS outbound',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+                CidrIp: '0.0.0.0/0',
+              },
+            ],
+            SecurityGroupIngress: [
+              {
+                Description: 'permit HTTPS inbound',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+                CidrIp: '0.0.0.0/0',
+              },
+            ],
             VpcId: {
               Ref: 'VPC',
             },
@@ -342,42 +145,89 @@ describe('vpc', () => {
                 Key: 'Name',
                 Value: {
                   // eslint-disable-next-line no-template-curly-in-string
-                  'Fn::Sub': '${AWS::StackName}-lambda-exec',
+                  'Fn::Sub': '${AWS::StackName}-sg',
                 },
               },
             ],
           },
         },
       };
-      const actual = buildLambdaSecurityGroup();
+      const actual = buildAppSecurityGroup();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
+  });
 
-    it('builds a Lambda security group with a custom name', () => {
+  describe('#buildDHCPOptions', () => {
+    it('builds a DHCP option set in us-east-1', () => {
       const expected = {
-        MyLambdaExecutionSecurityGroup: {
-          Type: 'AWS::EC2::SecurityGroup',
+        DHCPOptions: {
+          Type: 'AWS::EC2::DHCPOptions',
           Properties: {
-            GroupDescription: 'Lambda Execution Group',
-            VpcId: {
-              Ref: 'VPC',
-            },
+            DomainName: 'ec2.internal',
+            DomainNameServers: ['AmazonProvidedDNS'],
             Tags: [
               {
                 Key: 'Name',
                 Value: {
                   // eslint-disable-next-line no-template-curly-in-string
-                  'Fn::Sub': '${AWS::StackName}-lambda-exec',
+                  'Fn:Sub': '${AWS::StackName}-DHCPOptionsSet',
                 },
               },
             ],
           },
         },
+        VPCDHCPOptionsAssociation: {
+          Type: 'AWS::EC2::VPCDHCPOptionsAssociation',
+          Properties: {
+            VpcId: {
+              Ref: 'VPC',
+            },
+            DhcpOptionsId: {
+              Ref: 'DHCPOptions',
+            },
+          },
+        },
       };
-      const actual = buildLambdaSecurityGroup({
-        name: 'MyLambdaExecutionSecurityGroup',
-      });
+      const actual = buildDHCPOptions('us-east-1');
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+
+    it('builds a DHCP option set in us-west-2', () => {
+      const expected = {
+        DHCPOptions: {
+          Type: 'AWS::EC2::DHCPOptions',
+          Properties: {
+            DomainName: {
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::Region}.compute.internal',
+            },
+            DomainNameServers: ['AmazonProvidedDNS'],
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn:Sub': '${AWS::StackName}-DHCPOptionsSet',
+                },
+              },
+            ],
+          },
+        },
+        VPCDHCPOptionsAssociation: {
+          Type: 'AWS::EC2::VPCDHCPOptionsAssociation',
+          Properties: {
+            VpcId: {
+              Ref: 'VPC',
+            },
+            DhcpOptionsId: {
+              Ref: 'DHCPOptions',
+            },
+          },
+        },
+      };
+      const actual = buildDHCPOptions('us-west-2');
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/__tests__/vpce.test.js
+++ b/__tests__/vpce.test.js
@@ -1,8 +1,4 @@
-const {
-  buildEndpointServices,
-  buildVPCEndpoint,
-  buildVPCEndpointSecurityGroup,
-} = require('../src/vpce');
+const { buildEndpointServices, buildVPCEndpoint } = require('../src/vpce');
 
 describe('vpce', () => {
   describe('#buildEndpointServices', () => {
@@ -92,7 +88,7 @@ describe('vpce', () => {
             PrivateDnsEnabled: true,
             SecurityGroupIds: [
               {
-                Ref: 'EndpointSecurityGroup',
+                Ref: 'AppSecurityGroup',
               },
             ],
             SubnetIds: [
@@ -124,7 +120,7 @@ describe('vpce', () => {
             PrivateDnsEnabled: true,
             SecurityGroupIds: [
               {
-                Ref: 'EndpointSecurityGroup',
+                Ref: 'AppSecurityGroup',
               },
             ],
             SubnetIds: [
@@ -196,7 +192,7 @@ describe('vpce', () => {
             PrivateDnsEnabled: true,
             SecurityGroupIds: [
               {
-                Ref: 'EndpointSecurityGroup',
+                Ref: 'AppSecurityGroup',
               },
             ],
             SubnetIds: [
@@ -218,45 +214,6 @@ describe('vpce', () => {
       const actual = buildVPCEndpoint('sagemaker.runtime-fips', {
         subnetIds: [{ Ref: 'AppSubnet1' }],
       });
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-  });
-
-  describe('#buildVPCEndpointSecurityGroup', () => {
-    it('builds a endpoint security group with no options', () => {
-      const expected = {
-        EndpointSecurityGroup: {
-          Type: 'AWS::EC2::SecurityGroup',
-          Properties: {
-            GroupDescription: 'VPC Endpoint Security Group',
-            VpcId: {
-              Ref: 'VPC',
-            },
-            SecurityGroupIngress: [
-              {
-                SourceSecurityGroupId: {
-                  Ref: 'AppSecurityGroup',
-                },
-                Description: 'Allow inbound HTTPS traffic from AppSecurityGroup',
-                IpProtocol: 'tcp',
-                FromPort: 443,
-                ToPort: 443,
-              },
-            ],
-            Tags: [
-              {
-                Key: 'Name',
-                Value: {
-                  // eslint-disable-next-line no-template-curly-in-string
-                  'Fn::Sub': '${AWS::StackName}-vpce',
-                },
-              },
-            ],
-          },
-        },
-      };
-      const actual = buildVPCEndpointSecurityGroup();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/__tests__/vpce.test.js
+++ b/__tests__/vpce.test.js
@@ -1,7 +1,7 @@
 const {
   buildEndpointServices,
   buildVPCEndpoint,
-  buildLambdaVPCEndpointSecurityGroup,
+  buildVPCEndpointSecurityGroup,
 } = require('../src/vpce');
 
 describe('vpce', () => {
@@ -23,16 +23,8 @@ describe('vpce', () => {
               },
             ],
             ServiceName: {
-              'Fn::Join': [
-                '.',
-                [
-                  'com.amazonaws',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  's3',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': 'com.amazonaws.${AWS::Region}.s3',
             },
             PolicyDocument: {
               Statement: [
@@ -67,16 +59,8 @@ describe('vpce', () => {
               },
             ],
             ServiceName: {
-              'Fn::Join': [
-                '.',
-                [
-                  'com.amazonaws',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  'dynamodb',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': 'com.amazonaws.${AWS::Region}.dynamodb',
             },
             PolicyDocument: {
               Statement: [
@@ -108,7 +92,7 @@ describe('vpce', () => {
             PrivateDnsEnabled: true,
             SecurityGroupIds: [
               {
-                Ref: 'LambdaEndpointSecurityGroup',
+                Ref: 'EndpointSecurityGroup',
               },
             ],
             SubnetIds: [
@@ -117,16 +101,8 @@ describe('vpce', () => {
               },
             ],
             ServiceName: {
-              'Fn::Join': [
-                '.',
-                [
-                  'com.amazonaws',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  'kms',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': 'com.amazonaws.${AWS::Region}.kms',
             },
             VpcEndpointType: 'Interface',
             VpcId: {
@@ -148,7 +124,7 @@ describe('vpce', () => {
             PrivateDnsEnabled: true,
             SecurityGroupIds: [
               {
-                Ref: 'LambdaEndpointSecurityGroup',
+                Ref: 'EndpointSecurityGroup',
               },
             ],
             SubnetIds: [
@@ -157,16 +133,8 @@ describe('vpce', () => {
               },
             ],
             ServiceName: {
-              'Fn::Join': [
-                '.',
-                [
-                  'com.amazonaws',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  'sagemaker.runtime-fips',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': 'com.amazonaws.${AWS::Region}.sagemaker.runtime-fips',
             },
             VpcEndpointType: 'Interface',
             VpcId: {
@@ -193,16 +161,8 @@ describe('vpce', () => {
               },
             ],
             ServiceName: {
-              'Fn::Join': [
-                '.',
-                [
-                  'com.amazonaws',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  's3',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': 'com.amazonaws.${AWS::Region}.s3',
             },
             PolicyDocument: {
               Statement: [
@@ -236,7 +196,7 @@ describe('vpce', () => {
             PrivateDnsEnabled: true,
             SecurityGroupIds: [
               {
-                Ref: 'LambdaEndpointSecurityGroup',
+                Ref: 'EndpointSecurityGroup',
               },
             ],
             SubnetIds: [
@@ -245,16 +205,8 @@ describe('vpce', () => {
               },
             ],
             ServiceName: {
-              'Fn::Join': [
-                '.',
-                [
-                  'com.amazonaws',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  'sagemaker.runtime-fips',
-                ],
-              ],
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': 'com.amazonaws.${AWS::Region}.sagemaker.runtime-fips',
             },
             VpcEndpointType: 'Interface',
             VpcId: {
@@ -271,22 +223,22 @@ describe('vpce', () => {
     });
   });
 
-  describe('#buildLambdaVPCEndpointSecurityGroup', () => {
-    it('builds a Lambda endpoint security group with no options', () => {
+  describe('#buildVPCEndpointSecurityGroup', () => {
+    it('builds a endpoint security group with no options', () => {
       const expected = {
-        LambdaEndpointSecurityGroup: {
+        EndpointSecurityGroup: {
           Type: 'AWS::EC2::SecurityGroup',
           Properties: {
-            GroupDescription: 'Lambda access to VPC endpoints',
+            GroupDescription: 'VPC Endpoint Security Group',
             VpcId: {
               Ref: 'VPC',
             },
             SecurityGroupIngress: [
               {
                 SourceSecurityGroupId: {
-                  Ref: 'LambdaExecutionSecurityGroup',
+                  Ref: 'AppSecurityGroup',
                 },
-                Description: 'Allow inbound HTTPS traffic from LambdaExecutionSecurityGroup',
+                Description: 'Allow inbound HTTPS traffic from AppSecurityGroup',
                 IpProtocol: 'tcp',
                 FromPort: 443,
                 ToPort: 443,
@@ -297,53 +249,14 @@ describe('vpce', () => {
                 Key: 'Name',
                 Value: {
                   // eslint-disable-next-line no-template-curly-in-string
-                  'Fn::Sub': '${AWS::StackName}-lambda-endpoint',
+                  'Fn::Sub': '${AWS::StackName}-vpce',
                 },
               },
             ],
           },
         },
       };
-      const actual = buildLambdaVPCEndpointSecurityGroup();
-      expect(actual).toEqual(expected);
-      expect.assertions(1);
-    });
-
-    it('builds a Lambda security group with a custom name', () => {
-      const expected = {
-        MyLambdaEndpointSecurityGroup: {
-          Type: 'AWS::EC2::SecurityGroup',
-          Properties: {
-            GroupDescription: 'Lambda access to VPC endpoints',
-            VpcId: {
-              Ref: 'VPC',
-            },
-            SecurityGroupIngress: [
-              {
-                SourceSecurityGroupId: {
-                  Ref: 'LambdaExecutionSecurityGroup',
-                },
-                Description: 'Allow inbound HTTPS traffic from LambdaExecutionSecurityGroup',
-                IpProtocol: 'tcp',
-                FromPort: 443,
-                ToPort: 443,
-              },
-            ],
-            Tags: [
-              {
-                Key: 'Name',
-                Value: {
-                  // eslint-disable-next-line no-template-curly-in-string
-                  'Fn::Sub': '${AWS::StackName}-lambda-endpoint',
-                },
-              },
-            ],
-          },
-        },
-      };
-      const actual = buildLambdaVPCEndpointSecurityGroup({
-        name: 'MyLambdaEndpointSecurityGroup',
-      });
+      const actual = buildVPCEndpointSecurityGroup();
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "aws-sdk": "2.708.0",
     "serverless": "1.74.1",
-    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#jp-ssm",
+    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#master",
     "serverless-webpack": "5.3.2",
     "webpack": "4.43.0",
     "webpack-node-externals": "1.7.2"

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "aws-sdk": "2.708.0",
     "serverless": "1.74.1",
-    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#master",
+    "serverless-vpc-plugin": "smoketurner/serverless-vpc-plugin#jp-ssm",
     "serverless-webpack": "5.3.2",
     "webpack": "4.43.0",
     "webpack-node-externals": "1.7.2"

--- a/example/resources/rds_cf.yml
+++ b/example/resources/rds_cf.yml
@@ -8,21 +8,39 @@ Resources:
       Parameters:
         rds.force_ssl: 1
 
+  AppSecurityGroupEgress:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    Properties:
+      Description: 'permit PostgreSQL (5432) to DBSecurityGroup'
+      DestinationSecurityGroupId: !Ref DBSecurityGroup
+      FromPort: 5432
+      GroupId: !GetAtt AppSecurityGroup.GroupId
+      IpProtocol: tcp
+      ToPort: 5432
+
   DBSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      GroupDescription: 'RDS Database'
+      GroupDescription: 'RDS Security Group'
+      SecurityGroupEgress:
+        - Description: 'deny all outbound'
+          IpProtocol: '-1'
+          CidrIp: '127.0.0.1/32'
       SecurityGroupIngress:
-        - Description: 'Allow PostgreSQL (5432) from AppSecurityGroup'
+        - Description: 'permit PostgreSQL (5432) from AppSecurityGroup'
           FromPort: 5432
           IpProtocol: tcp
           SourceSecurityGroupId: !GetAtt AppSecurityGroup.GroupId
           ToPort: 5432
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [!Ref 'AWS::StackName', rds]]
       VpcId: !Ref VPC
 
   DBCluster:
     Type: 'AWS::RDS::DBCluster'
     DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
     Properties:
       DatabaseName: ${self:custom.databaseName}
       DBClusterIdentifier: '${self:service}-${self:provider.stage}'

--- a/example/resources/rds_cf.yml
+++ b/example/resources/rds_cf.yml
@@ -11,12 +11,12 @@ Resources:
   DBSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      GroupDescription: 'RDS Database Access'
+      GroupDescription: 'RDS Database'
       SecurityGroupIngress:
-        - Description: 'Allow inbound PostgreSQL access from Lambda'
+        - Description: 'Allow PostgreSQL (5432) from AppSecurityGroup'
           FromPort: 5432
           IpProtocol: tcp
-          SourceSecurityGroupId: !GetAtt LambdaExecutionSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt AppSecurityGroup.GroupId
           ToPort: 5432
       VpcId: !Ref VPC
 

--- a/example/resources/rds_cf.yml
+++ b/example/resources/rds_cf.yml
@@ -49,20 +49,6 @@ Resources:
       VpcSecurityGroupIds:
         - !Ref DBSecurityGroup
 
-  DBVpcEndpoint:
-    Type: 'AWS::EC2::VPCEndpoint'
-    Properties:
-      PrivateDnsEnabled: true
-      ServiceName: !Join ['.', ['com.amazonaws', !Ref 'AWS::Region', 'rds-data']]
-      SecurityGroupIds:
-        - !Ref LambdaEndpointSecurityGroup
-      SubnetIds:
-        - !Ref AppSubnet1
-        - !Ref AppSubnet2
-        - !Ref AppSubnet3
-      VpcEndpointType: Interface
-      VpcId: !Ref VPC
-
 Outputs:
   DBClusterAddress:
     Description: RDS Cluster Address

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -14,6 +14,12 @@ provider:
   environment:
     AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
     NODE_ENV: development
+  logs:
+    restApi:
+      accessLogging: false
+      executionLogging: false
+      fullExecutionData: false
+      roleManagedExternally: true
 
 plugins:
   - serverless-vpc-plugin
@@ -30,12 +36,14 @@ custom:
     cidrBlock: '10.0.0.0/16'
     createDbSubnet: true
     createNatInstance: true
+    createParameters: true
     zones:
       - us-east-1a
       - us-east-1b
       - us-east-1c
     services:
       - secretsmanager
+      - rds-data
   webpack:
     includeModules:
       forceExclude:

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -5,6 +5,7 @@ provider:
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'us-east-1'}
+  profile: jplock
   versionFunctions: false
   logRetentionInDays: 1
   deploymentBucket:
@@ -35,7 +36,7 @@ custom:
   vpcConfig:
     cidrBlock: '10.0.0.0/16'
     createDbSubnet: true
-    createNatInstance: true
+    createNatInstance: false
     createParameters: true
     zones:
       - us-east-1a
@@ -44,6 +45,8 @@ custom:
     services:
       - secretsmanager
       - rds-data
+    subnetGroups:
+      - rds
   webpack:
     includeModules:
       forceExclude:

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -45,6 +45,7 @@ custom:
     services:
       - secretsmanager
       - rds-data
+      - s3
     subnetGroups:
       - rds
   webpack:

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -5,7 +5,6 @@ provider:
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'us-east-1'}
-  profile: jplock
   versionFunctions: false
   logRetentionInDays: 1
   deploymentBucket:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-plugin",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,28 +15,28 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/core": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.3.tgz",
-      "integrity": "sha512-5YqWxYE3pyhIi84L84YcwjeEgS+fa7ZjK6IBVGTjDVfm64njkR2lfDhVR5OudLk8x2GK59YoSyVv+L/03k1q9w==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.4.tgz",
+      "integrity": "sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.3",
-        "@babel/generator": "^7.10.3",
-        "@babel/helper-module-transforms": "^7.10.1",
-        "@babel/helpers": "^7.10.1",
-        "@babel/parser": "^7.10.3",
-        "@babel/template": "^7.10.3",
-        "@babel/traverse": "^7.10.3",
-        "@babel/types": "^7.10.3",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.10.4",
+        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helpers": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -47,47 +47,13 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
-          "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.10.3"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
-          "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
-          "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.3",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.3.tgz",
-          "integrity": "sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "minimist": "^1.2.5"
           }
         },
         "semver": {
@@ -105,12 +71,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.3.tgz",
-      "integrity": "sha512-drt8MUHbEqRzNR0xnF8nMehbY11b1SDkRw03PSNH/3Rb2Z35oxkddVSi3rcaak0YJQ86PCuE7Qx1jSFhbLNBMA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
+      "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.3",
+        "@babel/types": "^7.10.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -125,128 +91,128 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.3.tgz",
-      "integrity": "sha512-FvSj2aiOd8zbeqijjgqdMDSyxsGHaMt5Tr0XjQsGKHD3/1FP3wksjnLAWzxw7lvXiej8W1Jt47SKTZ6upQNiRw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.3",
-        "@babel/template": "^7.10.3",
-        "@babel/types": "^7.10.3"
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.3.tgz",
-      "integrity": "sha512-iUD/gFsR+M6uiy69JA6fzM5seno8oE85IYZdbVVEuQaZlEzMO2MXblh+KSPJgsZAUx0EEbWXU0yJaW7C9CdAVg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.3"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.3.tgz",
-      "integrity": "sha512-q7+37c4EPLSjNb2NmWOjNwj0+BOyYlssuQ58kHEWk1Z78K5i8vTUsteq78HMieRPQSl/NtpQyJfdjt3qZ5V2vw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
+      "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.3"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.3.tgz",
-      "integrity": "sha512-Jtqw5M9pahLSUWA+76nhK9OG8nwYXzhQzVIGFoNaHnXF/r4l7kz4Fl0UAW7B6mqC5myoJiBP5/YQlXQTMfHI9w==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.3"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
-      "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
+      "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.10.1",
-        "@babel/helper-replace-supers": "^7.10.1",
-        "@babel/helper-simple-access": "^7.10.1",
-        "@babel/helper-split-export-declaration": "^7.10.1",
-        "@babel/template": "^7.10.1",
-        "@babel/types": "^7.10.1",
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4",
         "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.3.tgz",
-      "integrity": "sha512-kT2R3VBH/cnSz+yChKpaKRJQJWxdGoc6SjioRId2wkeV3bK0wLLioFpJROrX0U4xr/NmxSSAWT/9Ih5snwIIzg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.3"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz",
-      "integrity": "sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-      "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.10.1",
-        "@babel/helper-optimise-call-expression": "^7.10.1",
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
-      "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-      "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+      "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
-      "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.10.1",
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/highlight": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -265,9 +231,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
-      "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
+      "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -289,21 +255,21 @@
       }
     },
     "@babel/plugin-syntax-class-properties": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.1.tgz",
-      "integrity": "sha512-Gf2Yx/iRs1JREDtVZ56OrjjgFHCaldpTnuy9BHla10qyVT3YkIIGEtoDWhyop0ksu1GvNjHIoYRBqm3zoR1jyQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+      "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-syntax-import-meta": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.1.tgz",
-      "integrity": "sha512-ypC4jwfIVF72og0dgvEcFRdOM2V9Qm1tu7RGmdZOlhsccyK0wisXmMObGuWEOd5jQ+K9wcIgSNftCpk2vkjUfQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -316,12 +282,12 @@
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.1.tgz",
-      "integrity": "sha512-XyHIFa9kdrgJS91CUH+ccPVTnJShr8nLGc5bG2IhGXv5p1Rd+8BleGE5yzIg2Nc1QZAdHDa0Qp4m6066OL96Iw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -334,12 +300,12 @@
       }
     },
     "@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.1.tgz",
-      "integrity": "sha512-uTd0OsHrpe3tH5gRPTxG8Voh99/WCU78vIm5NMRYPAqC8lR4vajt6KkCAknCHrx24vkPdd/05yfdGSB4EIY2mg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -370,121 +336,33 @@
       }
     },
     "@babel/template": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.3.tgz",
-      "integrity": "sha512-5BjI4gdtD+9fHZUsaxPHPNpwa+xRkDO7c7JbhYn2afvrkDu5SfAAbi9AIMXw2xEhO/BR35TqiW97IqNvCo/GqA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.3",
-        "@babel/parser": "^7.10.3",
-        "@babel/types": "^7.10.3"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
-          "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.10.3"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
-          "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
-          "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.3",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.3.tgz",
-          "integrity": "sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.3.tgz",
-      "integrity": "sha512-qO6623eBFhuPm0TmmrUFMT1FulCmsSeJuVGhiLodk2raUDFhhTECLd9E9jC4LBIWziqt4wgF6KuXE4d+Jz9yug==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
+      "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.3",
-        "@babel/generator": "^7.10.3",
-        "@babel/helper-function-name": "^7.10.3",
-        "@babel/helper-split-export-declaration": "^7.10.1",
-        "@babel/parser": "^7.10.3",
-        "@babel/types": "^7.10.3",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.10.4",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
-          "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.10.3"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
-          "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
-          "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.3",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.3.tgz",
-          "integrity": "sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -494,22 +372,14 @@
       }
     },
     "@babel/types": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.3.tgz",
-      "integrity": "sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
+      "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.3",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
-          "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
-          "dev": true
-        }
       }
     },
     "@bcoe/v8-coverage": {
@@ -652,12 +522,6 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -735,14 +599,6 @@
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
         "v8-to-istanbul": "^4.1.3"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "@jest/source-map": {
@@ -754,14 +610,6 @@
         "callsites": "^3.0.0",
         "graceful-fs": "^4.2.4",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "@jest/test-result": {
@@ -787,14 +635,6 @@
         "jest-haste-map": "^26.1.0",
         "jest-runner": "^26.1.0",
         "jest-runtime": "^26.1.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "@jest/transform": {
@@ -818,14 +658,6 @@
         "slash": "^3.0.0",
         "source-map": "^0.6.1",
         "write-file-atomic": "^3.0.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "@jest/types": {
@@ -1030,9 +862,9 @@
       }
     },
     "@serverless/enterprise-plugin": {
-      "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.6.14.tgz",
-      "integrity": "sha512-JB26Anb5t80/wZzF0s4EIh2qSrvHDTaiLjgeFoCoEzBJZlSxZTJHva1ei3rfni0DwAtg4tm0qdRG2opyrqBP2A==",
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.6.15.tgz",
+      "integrity": "sha512-g0qCNei+nV+CaP+D/k89PnhSoYEtT13t1A+wW38EjC6IhfsnVUQuHyNObUuu469gJbLr1D856CjVvGQ5H23Wng==",
       "dev": true,
       "requires": {
         "@serverless/event-mocks": "^1.1.1",
@@ -1092,16 +924,6 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
           }
         },
         "semver": {
@@ -1217,26 +1039,10 @@
             "lodash": "^4.17.14"
           }
         },
-        "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
         "pify": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
           "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-          "dev": true
-        },
-        "ws": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
           "dev": true
         }
       }
@@ -1611,9 +1417,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+      "version": "14.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
+      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1729,9 +1535,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-globals": {
@@ -1802,12 +1608,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -2185,9 +1985,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
     },
     "axios": {
@@ -2213,14 +2013,6 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "babel-plugin-istanbul": {
@@ -2445,12 +2237,6 @@
             "string-width": "^3.0.0"
           }
         },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2467,38 +2253,6 @@
           "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
           "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
           "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
         },
         "type-fest": {
           "version": "0.3.1",
@@ -2706,9 +2460,9 @@
       }
     },
     "chalk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -2938,6 +2692,31 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
       }
     },
     "clone-response": {
@@ -3246,9 +3025,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-      "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -4015,9 +3794,9 @@
       }
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
     "enabled": {
@@ -4254,9 +4033,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",
@@ -4349,24 +4128,6 @@
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
       }
     },
     "eslint-config-airbnb-base": {
@@ -4488,15 +4249,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
         }
       }
     },
@@ -4529,18 +4281,18 @@
       }
     },
     "eslint-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "esniff": {
@@ -4562,14 +4314,6 @@
         "acorn": "^7.2.0",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.2.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -4945,9 +4689,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-diff": {
@@ -5734,9 +5478,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "graceful-readlink": {
@@ -6148,12 +5892,6 @@
             "escape-string-regexp": "^1.0.5"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -6330,9 +6068,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-generator-fn": {
@@ -6661,12 +6399,6 @@
         "jest-cli": "^26.1.0"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        },
         "jest-cli": {
           "version": "26.1.0",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.1.0.tgz",
@@ -6768,14 +6500,6 @@
         "jest-validate": "^26.1.0",
         "micromatch": "^4.0.2",
         "pretty-format": "^26.1.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "jest-diff": {
@@ -6864,14 +6588,6 @@
         "sane": "^4.0.3",
         "walker": "^1.0.7",
         "which": "^2.0.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "jest-jasmine2": {
@@ -6935,14 +6651,6 @@
         "micromatch": "^4.0.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "jest-mock": {
@@ -6991,12 +6699,6 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
-        },
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -7079,15 +6781,6 @@
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
           }
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
         }
       }
     },
@@ -7127,14 +6820,6 @@
         "jest-worker": "^26.1.0",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "jest-runtime": {
@@ -7171,12 +6856,6 @@
         "yargs": "^15.3.1"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -7192,14 +6871,6 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "jest-snapshot": {
@@ -7223,14 +6894,6 @@
         "natural-compare": "^1.4.0",
         "pretty-format": "^26.1.0",
         "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "jest-util": {
@@ -7244,14 +6907,6 @@
         "graceful-fs": "^4.2.4",
         "is-ci": "^2.0.0",
         "micromatch": "^4.0.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "jest-validate": {
@@ -7330,9 +6985,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -7452,12 +7107,12 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.0"
       }
     },
     "jsonata": {
@@ -9012,6 +8667,14 @@
         "@types/long": "^4.0.1",
         "@types/node": "^13.7.0",
         "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
+          "integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw==",
+          "dev": true
+        }
       }
     },
     "prr": {
@@ -9346,9 +9009,9 @@
       }
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -9770,9 +9433,9 @@
       },
       "dependencies": {
         "@serverless/components": {
-          "version": "2.31.7",
-          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-2.31.7.tgz",
-          "integrity": "sha512-Mq0nZPeuGaTMQqr8l0QNLbf3nJSxiAru19zg5MrjgcZuHixoDASL6GqOjGt5uwta2i33U9BTdMDq3/MrRmsSsA==",
+          "version": "2.31.10",
+          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-2.31.10.tgz",
+          "integrity": "sha512-GueB1ivJpcU6Et5x8YWyGKhU7Ud+wu1S68jfeg/DZrS2v3wHF4ESbHDIVj4sSeOhm4gyD0056fcpssDZu1uA4A==",
           "dev": true,
           "requires": {
             "@serverless/inquirer": "^1.1.2",
@@ -9838,9 +9501,9 @@
           "dev": true
         },
         "aws-sdk": {
-          "version": "2.707.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.707.0.tgz",
-          "integrity": "sha512-nt55Z9wQKFodOuwElF3222Thc3kDVnaC4rwemPEHIM1cVGPQe6E5yBfc6AwtYmSo6eoMMEWd6XO5wG2am9PW0w==",
+          "version": "2.708.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.708.0.tgz",
+          "integrity": "sha512-5xXOvbgBXUUKBaJlJUcJIFc2EVMa4Z4f7ILbKIpApoFonW1kHiwBLMBi0MarY4aco7RaodgbqhaOBar4kmSHKw==",
           "dev": true,
           "requires": {
             "buffer": "4.9.2",
@@ -9884,12 +9547,6 @@
             "supports-color": "^5.3.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        },
         "ignore": {
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -9901,16 +9558,6 @@
           "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-1.1.0.tgz",
           "integrity": "sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE=",
           "dev": true
-        },
-        "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
         },
         "p-limit": {
           "version": "2.3.0",
@@ -9958,12 +9605,6 @@
             "imurmurhash": "^0.1.4",
             "signal-exit": "^3.0.2"
           }
-        },
-        "ws": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
-          "dev": true
         }
       }
     },
@@ -10118,14 +9759,6 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
       }
     },
     "snapdragon": {
@@ -10380,9 +10013,9 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -10390,15 +10023,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -10566,14 +10199,31 @@
       }
     },
     "string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "string.prototype.trimend": {
@@ -10812,46 +10462,6 @@
         "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "tabtab": {
@@ -11168,23 +10778,12 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
       }
     },
     "tslib": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tsutils": {
@@ -11431,12 +11030,6 @@
             "ci-info": "^1.5.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -11682,12 +11275,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -11814,6 +11401,29 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
         }
       }
     },
@@ -11845,9 +11455,9 @@
       }
     },
     "ws": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
-      "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
       "dev": true
     },
     "xdg-basedir": {
@@ -11943,6 +11553,12 @@
         "yargs-parser": "^18.1.1"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -11952,6 +11568,12 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -11991,6 +11613,17 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "src/index.js",
   "scripts": {
-    "test": "SLS_DEBUG=* jest --coverage"
+    "test": "SLS_DEBUG=* DEBUG=nock.* jest --coverage"
   },
   "dependencies": {
     "cidr-split": "0.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-plugin",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "engines": {
     "node": ">=8.0"
   },
@@ -23,7 +23,7 @@
   ],
   "main": "src/index.js",
   "scripts": {
-    "test": "SLS_DEBUG=* DEBUG=nock.* jest --coverage"
+    "test": "SLS_DEBUG=* jest --coverage"
   },
   "dependencies": {
     "cidr-split": "0.1.2"

--- a/src/az.js
+++ b/src/az.js
@@ -1,6 +1,7 @@
 const { APP_SUBNET, PUBLIC_SUBNET, DB_SUBNET } = require('./constants');
 const { buildEIP, buildNatGateway } = require('./natgw');
-const { buildSubnet, buildRoute, buildRouteTable, buildRouteTableAssociation } = require('./vpc');
+const { buildSubnet } = require('./subnets');
+const { buildRoute, buildRouteTable, buildRouteTableAssociation } = require('./routes');
 
 /**
  * Builds the Availability Zones for the region.
@@ -46,13 +47,13 @@ function buildAvailabilityZones(
 
       // App Subnet
       buildSubnet(APP_SUBNET, position, zone, subnets.get(zone).get(APP_SUBNET)),
-      buildRouteTable(APP_SUBNET, position, zone),
+      buildRouteTable(APP_SUBNET, position),
       buildRouteTableAssociation(APP_SUBNET, position),
       // no default route on Application subnet
 
       // Public Subnet
       buildSubnet(PUBLIC_SUBNET, position, zone, subnets.get(zone).get(PUBLIC_SUBNET)),
-      buildRouteTable(PUBLIC_SUBNET, position, zone),
+      buildRouteTable(PUBLIC_SUBNET, position),
       buildRouteTableAssociation(PUBLIC_SUBNET, position),
       buildRoute(PUBLIC_SUBNET, position, {
         GatewayId: 'InternetGateway',
@@ -76,7 +77,7 @@ function buildAvailabilityZones(
       Object.assign(
         resources,
         buildSubnet(DB_SUBNET, position, zone, subnets.get(zone).get(DB_SUBNET)),
-        buildRouteTable(DB_SUBNET, position, zone),
+        buildRouteTable(DB_SUBNET, position),
         buildRouteTableAssociation(DB_SUBNET, position),
         // no default route on DB subnet
       );

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -253,14 +253,14 @@ function buildBastionSecurityGroup(sourceIp = '0.0.0.0/0', { name = 'BastionSecu
         },
         SecurityGroupIngress: [
           {
-            Description: 'Allow inbound SSH access to the bastion host',
+            Description: 'permit inbound SSH',
             IpProtocol: 'tcp',
             FromPort: 22,
             ToPort: 22,
             CidrIp: sourceIp,
           },
           {
-            Description: 'Allow inbound ICMP to the bastion host',
+            Description: 'permit inbound ICMP',
             IpProtocol: 'icmp',
             FromPort: -1,
             ToPort: -1,

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -1,4 +1,4 @@
-const http = require('http');
+const https = require('https');
 
 const { PUBLIC_SUBNET } = require('./constants');
 
@@ -9,13 +9,13 @@ const { PUBLIC_SUBNET } = require('./constants');
  */
 function getPublicIp() {
   const options = {
-    host: 'checkip.amazonaws.com',
-    port: 80,
+    hostname: 'checkip.amazonaws.com',
+    port: 443,
     path: '/',
     timeout: 1000,
   };
   return new Promise((resolve, reject) => {
-    const req = http.get(options, (res) => {
+    const req = https.get(options, (res) => {
       const buffers = [];
       res.on('data', (data) => buffers.push(data));
       res.once('end', () => resolve(Buffer.concat(buffers).toString()));

--- a/src/flow_logs.js
+++ b/src/flow_logs.js
@@ -8,6 +8,7 @@ function buildLogBucket() {
     LogBucket: {
       Type: 'AWS::S3::Bucket',
       DeletionPolicy: 'Retain',
+      UpdateReplacePolicy: 'Retain',
       Properties: {
         AccessControl: 'LogDeliveryWrite',
         BucketEncryption: {

--- a/src/index.js
+++ b/src/index.js
@@ -193,11 +193,7 @@ class ServerlessVpcPlugin {
 
     if (createNatInstance && vpcNatAmi) {
       this.serverless.cli.log(`Provisioning NAT Instance using AMI ${vpcNatAmi}`);
-      Object.assign(
-        resources,
-        buildNatSecurityGroup(subnets.get(APP_SUBNET)),
-        buildNatInstance(vpcNatAmi, zones),
-      );
+      Object.assign(resources, buildNatSecurityGroup(), buildNatInstance(vpcNatAmi, zones));
     }
 
     if (createBastionHost) {

--- a/src/index.js
+++ b/src/index.js
@@ -245,11 +245,7 @@ class ServerlessVpcPlugin {
 
     // SSM Parameters
     if (createParameters) {
-      Object.assign(
-        resources,
-        buildParameter('VPC'),
-        buildParameter('LambdaExecutionSecurityGroup'),
-      );
+      Object.assign(resources, buildParameter('VPC'), buildParameter('AppSecurityGroup'));
 
       if (createDbSubnet && numZones > 1) {
         if (subnetGroups.includes('rds')) {
@@ -295,7 +291,7 @@ class ServerlessVpcPlugin {
     if (!Array.isArray(vpc.securityGroupIds)) {
       vpc.securityGroupIds = [];
     }
-    vpc.securityGroupIds.push({ Ref: 'LambdaExecutionSecurityGroup' });
+    vpc.securityGroupIds.push({ Ref: 'AppSecurityGroup' });
 
     if (!Array.isArray(vpc.subnetIds)) {
       vpc.subnetIds = [];

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const {
 } = require('./vpc');
 const { buildAppNetworkAcl, buildPublicNetworkAcl, buildDBNetworkAcl } = require('./nacl');
 const { buildSubnetGroups } = require('./subnet_groups');
-const { buildEndpointServices, buildVPCEndpointSecurityGroup } = require('./vpce');
+const { buildEndpointServices } = require('./vpce');
 const { buildLogBucket, buildLogBucketPolicy, buildVpcFlowLogs } = require('./flow_logs');
 const { buildBastion } = require('./bastion');
 const { buildNatInstance, buildNatSecurityGroup } = require('./nat_instance');
@@ -223,11 +223,7 @@ class ServerlessVpcPlugin {
       }
       this.serverless.cli.log(`Provisioning VPC endpoints for: ${services.join(', ')}`);
 
-      Object.assign(
-        resources,
-        buildEndpointServices(services, numZones),
-        buildVPCEndpointSecurityGroup(),
-      );
+      Object.assign(resources, buildEndpointServices(services, numZones));
     }
 
     if (createDbSubnet) {

--- a/src/nacl.js
+++ b/src/nacl.js
@@ -17,15 +17,7 @@ function buildNetworkAcl(name) {
           {
             Key: 'Name',
             Value: {
-              'Fn::Join': [
-                '-',
-                [
-                  {
-                    Ref: 'AWS::StackName',
-                  },
-                  name.toLowerCase(),
-                ],
-              ],
+              'Fn::Sub': `\${AWS::StackName}-${name.toLowerCase()}`,
             },
           },
         ],

--- a/src/natgw.js
+++ b/src/natgw.js
@@ -41,16 +41,12 @@ function buildNatGateway(position, zone) {
           {
             Key: 'Name',
             Value: {
-              'Fn::Join': [
-                '-',
-                [
-                  {
-                    Ref: 'AWS::StackName',
-                  },
-                  zone,
-                ],
-              ],
+              'Fn::Sub': `\${AWS::StackName}-${zone}`,
             },
+          },
+          {
+            Key: 'Network',
+            Value: 'Public',
           },
         ],
       },

--- a/src/outputs.js
+++ b/src/outputs.js
@@ -3,19 +3,17 @@ const { VALID_SUBNET_GROUPS } = require('./constants');
 /**
  * Append subnets to output
  *
- * @param {Array<String>} subnets
+ * @param {Array<Object>} subnets
  * @param {Object} outputs
  */
 function appendSubnets(subnets, outputs) {
-  if (Array.isArray(subnets) && subnets.length > 0) {
-    const subnetOutputs = subnets.map((subnet) => ({
-      [`${subnet.Ref}`]: {
-        Value: subnet,
-      },
-    }));
+  const subnetOutputs = subnets.map((subnet) => ({
+    [`${subnet.Ref}`]: {
+      Value: subnet,
+    },
+  }));
 
-    Object.assign(outputs, ...subnetOutputs);
-  }
+  Object.assign(outputs, ...subnetOutputs);
 }
 
 /**
@@ -25,48 +23,43 @@ function appendSubnets(subnets, outputs) {
  * @param {Object} outputs
  */
 function appendSubnetGroups(subnetGroups, outputs) {
-  if (Array.isArray(subnetGroups) && subnetGroups.length > 0) {
-    const typesToNames = {
-      rds: 'RDSSubnetGroup',
-      redshift: 'RedshiftSubnetGroup',
-      elasticache: 'ElastiCacheSubnetGroup',
-      dax: 'DAXSubnetGroup',
-    };
+  const typesToNames = {
+    rds: 'RDSSubnetGroup',
+    redshift: 'RedshiftSubnetGroup',
+    elasticache: 'ElastiCacheSubnetGroup',
+    dax: 'DAXSubnetGroup',
+  };
 
-    const subnetGroupOutputs = subnetGroups.map((subnetGroup) => ({
-      [typesToNames[subnetGroup]]: {
-        Description: `Subnet Group for ${subnetGroup}`,
-        Value: {
-          Ref: typesToNames[subnetGroup],
-        },
+  const subnetGroupOutputs = subnetGroups.map((subnetGroup) => ({
+    [typesToNames[subnetGroup]]: {
+      Description: `Subnet Group for ${subnetGroup}`,
+      Value: {
+        Ref: typesToNames[subnetGroup],
       },
-    }));
+    },
+  }));
 
-    Object.assign(outputs, ...subnetGroupOutputs);
-  }
+  Object.assign(outputs, ...subnetGroupOutputs);
 }
 
 /**
  * Append bastion host to output
  *
- * @param {Boolean} createBastionHost
  * @param {Object} outputs
  */
-function appendBastionHost(createBastionHost, outputs) {
-  if (createBastionHost) {
-    // eslint-disable-next-line no-param-reassign
-    outputs.BastionSSHUser = {
-      Description: 'SSH username for the Bastion host',
-      Value: 'ec2-user',
-    };
-    // eslint-disable-next-line no-param-reassign
-    outputs.BastionEIP = {
-      Description: 'Public IP of Bastion host',
-      Value: {
-        Ref: 'BastionEIP',
-      },
-    };
-  }
+function appendBastionHost(outputs) {
+  // eslint-disable-next-line no-param-reassign
+  outputs.BastionSSHUser = {
+    Description: 'SSH username for the Bastion host',
+    Value: 'ec2-user',
+  };
+  // eslint-disable-next-line no-param-reassign
+  outputs.BastionEIP = {
+    Description: 'Public IP of Bastion host',
+    Value: {
+      Ref: 'BastionEIP',
+    },
+  };
 }
 
 /**
@@ -75,17 +68,15 @@ function appendBastionHost(createBastionHost, outputs) {
  * @param {Boolean} exportOutputs
  * @param {Object} outputs
  */
-function appendExports(exportOutputs, outputs) {
-  if (exportOutputs) {
-    Object.entries(outputs).forEach(([name, value]) => {
-      // eslint-disable-next-line no-param-reassign
-      value.Export = {
-        Name: {
-          'Fn::Join': ['-', [{ Ref: 'AWS::StackName' }, name]],
-        },
-      };
-    });
-  }
+function appendExports(outputs) {
+  Object.entries(outputs).forEach(([name, value]) => {
+    // eslint-disable-next-line no-param-reassign
+    value.Export = {
+      Name: {
+        'Fn::Join': ['-', [{ Ref: 'AWS::StackName' }, name]],
+      },
+    };
+  });
 }
 
 /**
@@ -125,11 +116,17 @@ function buildOutputs({
     appendSubnetGroups(subnetGroups, outputs);
   }
 
-  appendSubnets(subnets, outputs);
+  if (Array.isArray(subnets) && subnets.length > 0) {
+    appendSubnets(subnets, outputs);
+  }
 
-  appendBastionHost(createBastionHost, outputs);
+  if (createBastionHost) {
+    appendBastionHost(outputs);
+  }
 
-  appendExports(exportOutputs, outputs);
+  if (exportOutputs) {
+    appendExports(outputs);
+  }
 
   return outputs;
 }

--- a/src/outputs.js
+++ b/src/outputs.js
@@ -65,7 +65,6 @@ function appendBastionHost(outputs) {
 /**
  * Append export outputs
  *
- * @param {Boolean} exportOutputs
  * @param {Object} outputs
  */
 function appendExports(outputs) {
@@ -73,7 +72,7 @@ function appendExports(outputs) {
     // eslint-disable-next-line no-param-reassign
     value.Export = {
       Name: {
-        'Fn::Join': ['-', [{ Ref: 'AWS::StackName' }, name]],
+        'Fn::Sub': `\${AWS::StackName}-${name}`,
       },
     };
   });
@@ -88,7 +87,6 @@ function appendExports(outputs) {
  * @param {Boolean} exportOutputs
  * @return {Object}
  */
-
 function buildOutputs({
   createBastionHost = false,
   subnetGroups = VALID_SUBNET_GROUPS,
@@ -103,10 +101,15 @@ function buildOutputs({
       },
     },
     LambdaExecutionSecurityGroupId: {
-      Description:
-        'Security Group logical resource ID that the Lambda functions use when executing within the VPC',
+      Description: 'DEPRECATED - Please use AppSecurityGroupId instead',
       Value: {
-        Ref: 'LambdaExecutionSecurityGroup',
+        Ref: 'AppSecurityGroup',
+      },
+    },
+    AppSecurityGroupId: {
+      Description: 'Security Group ID that the applications use when executing within the VPC',
+      Value: {
+        Ref: 'AppSecurityGroup',
       },
     },
   };

--- a/src/parameters.js
+++ b/src/parameters.js
@@ -1,0 +1,41 @@
+/**
+ * Build an AWS Systems Manager Parmeter
+ *
+ * @param {String} LogicalResourceId
+ * @param {Object} params
+ * @return {Object}
+ */
+function buildParameter(LogicalResourceId, { Value = null } = {}) {
+  let Type = 'String';
+  if (Value) {
+    if (Array.isArray(Value)) {
+      Type = 'StringList';
+      // eslint-disable-next-line no-param-reassign
+      Value = {
+        'Fn::Join': [',', Value],
+      };
+    }
+  } else {
+    // eslint-disable-next-line no-param-reassign
+    Value = { Ref: LogicalResourceId };
+  }
+
+  const cfName = `Parameter${LogicalResourceId}`;
+  return {
+    [cfName]: {
+      Type: 'AWS::SSM::Parameter',
+      Properties: {
+        Name: {
+          'Fn::Sub': `/SLS/\${AWS::StackName}/${LogicalResourceId}`,
+        },
+        Tier: 'Standard',
+        Type,
+        Value,
+      },
+    },
+  };
+}
+
+module.exports = {
+  buildParameter,
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,121 @@
+const { PUBLIC_SUBNET } = require('./constants');
+
+/**
+ * Build a RouteTable in a given AZ
+ *
+ * @param {String} name
+ * @param {Number} position
+ * @return {Object}
+ */
+function buildRouteTable(name, position) {
+  const cfName = `${name}RouteTable${position}`;
+
+  const Tags = [
+    {
+      Key: 'Name',
+      Value: {
+        'Fn::Sub': `\${AWS::StackName}-${name.toLowerCase()}-\${${name}Subnet${position}.AvailabilityZone}`,
+      },
+    },
+  ];
+
+  if (name === PUBLIC_SUBNET) {
+    Tags.push({ Key: 'Network', Value: 'Public' });
+  } else {
+    Tags.push({ Key: 'Network', Value: 'Private' });
+  }
+
+  return {
+    [cfName]: {
+      Type: 'AWS::EC2::RouteTable',
+      Properties: {
+        VpcId: {
+          Ref: 'VPC',
+        },
+        Tags,
+      },
+    },
+  };
+}
+
+/**
+ * Build a RouteTableAssociation
+ *
+ * @param {String} name
+ * @param {Number} position
+ * @return {Object}
+ */
+function buildRouteTableAssociation(name, position) {
+  const cfName = `${name}RouteTableAssociation${position}`;
+  return {
+    [cfName]: {
+      Type: 'AWS::EC2::SubnetRouteTableAssociation',
+      Properties: {
+        RouteTableId: {
+          Ref: `${name}RouteTable${position}`,
+        },
+        SubnetId: {
+          Ref: `${name}Subnet${position}`,
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Build a Route for a NatGateway or InternetGateway
+ *
+ * @param {String} name
+ * @param {Number} position
+ * @param {Object} params
+ * @return {Object}
+ */
+function buildRoute(
+  name,
+  position,
+  { NatGatewayId = null, GatewayId = null, InstanceId = null } = {},
+) {
+  const route = {
+    Type: 'AWS::EC2::Route',
+    Properties: {
+      DestinationCidrBlock: '0.0.0.0/0',
+      RouteTableId: {
+        Ref: `${name}RouteTable${position}`,
+      },
+    },
+  };
+
+  // fixes "route table rtb-x and network gateway igw-x belong to different networks"
+  // see https://stackoverflow.com/questions/48865762
+  if (name === PUBLIC_SUBNET) {
+    route.DependsOn = ['InternetGatewayAttachment'];
+  }
+  if (NatGatewayId) {
+    route.Properties.NatGatewayId = {
+      Ref: NatGatewayId,
+    };
+  } else if (GatewayId) {
+    route.Properties.GatewayId = {
+      Ref: GatewayId,
+    };
+  } else if (InstanceId) {
+    route.Properties.InstanceId = {
+      Ref: InstanceId,
+    };
+  } else {
+    throw new Error(
+      'Unable to create route: either NatGatewayId, GatewayId or InstanceId must be provided',
+    );
+  }
+
+  const cfName = `${name}Route${position}`;
+  return {
+    [cfName]: route,
+  };
+}
+
+module.exports = {
+  buildRoute,
+  buildRouteTable,
+  buildRouteTableAssociation,
+};

--- a/src/subnet_groups.js
+++ b/src/subnet_groups.js
@@ -4,10 +4,9 @@ const { DB_SUBNET } = require('./constants');
  * Build an RDSubnetGroup for a given number of zones
  *
  * @param {Number} numZones Number of availability zones
- * @param {Objects} params
  * @return {Object}
  */
-function buildRDSSubnetGroup(numZones = 0, { name = 'RDSSubnetGroup' } = {}) {
+function buildRDSSubnetGroup(numZones = 0) {
   if (numZones < 1) {
     return {};
   }
@@ -18,7 +17,7 @@ function buildRDSSubnetGroup(numZones = 0, { name = 'RDSSubnetGroup' } = {}) {
   }
 
   return {
-    [name]: {
+    RDSSubnetGroup: {
       Type: 'AWS::RDS::DBSubnetGroup',
       Properties: {
         DBSubnetGroupName: {
@@ -37,10 +36,9 @@ function buildRDSSubnetGroup(numZones = 0, { name = 'RDSSubnetGroup' } = {}) {
  * Build an ElastiCacheSubnetGroup for a given number of zones
  *
  * @param {Number} numZones Number of availability zones
- * @param {Object} params
  * @return {Object}
  */
-function buildElastiCacheSubnetGroup(numZones = 0, { name = 'ElastiCacheSubnetGroup' } = {}) {
+function buildElastiCacheSubnetGroup(numZones = 0) {
   if (numZones < 1) {
     return {};
   }
@@ -51,7 +49,7 @@ function buildElastiCacheSubnetGroup(numZones = 0, { name = 'ElastiCacheSubnetGr
   }
 
   return {
-    [name]: {
+    ElastiCacheSubnetGroup: {
       Type: 'AWS::ElastiCache::SubnetGroup',
       Properties: {
         CacheSubnetGroupName: {
@@ -70,10 +68,9 @@ function buildElastiCacheSubnetGroup(numZones = 0, { name = 'ElastiCacheSubnetGr
  * Build an RedshiftSubnetGroup for a given number of zones
  *
  * @param {Number} numZones Number of availability zones
- * @param {Object} params
  * @return {Object}
  */
-function buildRedshiftSubnetGroup(numZones = 0, { name = 'RedshiftSubnetGroup' } = {}) {
+function buildRedshiftSubnetGroup(numZones = 0) {
   if (numZones < 1) {
     return {};
   }
@@ -84,7 +81,7 @@ function buildRedshiftSubnetGroup(numZones = 0, { name = 'RedshiftSubnetGroup' }
   }
 
   return {
-    [name]: {
+    RedshiftSubnetGroup: {
       Type: 'AWS::Redshift::ClusterSubnetGroup',
       Properties: {
         Description: {
@@ -100,10 +97,9 @@ function buildRedshiftSubnetGroup(numZones = 0, { name = 'RedshiftSubnetGroup' }
  * Build an DAXSubnetGroup for a given number of zones
  *
  * @param {Number} numZones Number of availability zones
- * @param {Object} params
  * @return {Object}
  */
-function buildDAXSubnetGroup(numZones = 0, { name = 'DAXSubnetGroup' } = {}) {
+function buildDAXSubnetGroup(numZones = 0) {
   if (numZones < 1) {
     return {};
   }
@@ -114,7 +110,7 @@ function buildDAXSubnetGroup(numZones = 0, { name = 'DAXSubnetGroup' } = {}) {
   }
 
   return {
-    [name]: {
+    DAXSubnetGroup: {
       Type: 'AWS::DAX::SubnetGroup',
       Properties: {
         SubnetGroupName: {

--- a/src/subnets.js
+++ b/src/subnets.js
@@ -77,7 +77,50 @@ function splitSubnets(cidrBlock, zones = []) {
   return mapping;
 }
 
+/**
+ * Create a subnet
+ *
+ * @param {String} name Name of subnet
+ * @param {Number} position Subnet position
+ * @param {String} zone Availability zone
+ * @param {String} cidrBlock Subnet CIDR block
+ * @return {Object}
+ */
+function buildSubnet(name, position, zone, cidrBlock) {
+  const cfName = `${name}Subnet${position}`;
+
+  const Tags = [
+    {
+      Key: 'Name',
+      Value: {
+        'Fn::Sub': `\${AWS::StackName}-${name.toLowerCase()}-${zone}`,
+      },
+    },
+  ];
+
+  if (name === PUBLIC_SUBNET) {
+    Tags.push({ Key: 'Network', Value: 'Public' });
+  } else {
+    Tags.push({ Key: 'Network', Value: 'Private' });
+  }
+
+  return {
+    [cfName]: {
+      Type: 'AWS::EC2::Subnet',
+      Properties: {
+        AvailabilityZone: zone,
+        CidrBlock: cidrBlock,
+        Tags,
+        VpcId: {
+          Ref: 'VPC',
+        },
+      },
+    },
+  };
+}
+
 module.exports = {
   splitVpc,
   splitSubnets,
+  buildSubnet,
 };

--- a/src/vpc.js
+++ b/src/vpc.js
@@ -152,7 +152,7 @@ function buildDHCPOptions(region) {
             Key: 'Name',
             Value: {
               // eslint-disable-next-line no-template-curly-in-string
-              'Fn:Sub': '${AWS::StackName}-DHCPOptionsSet',
+              'Fn::Sub': '${AWS::StackName}-DHCPOptionsSet',
             },
           },
         ],

--- a/src/vpce.js
+++ b/src/vpce.js
@@ -91,7 +91,6 @@ function buildEndpointServices(services = [], numZones = 0) {
 /**
  * Build a SecurityGroup to allow the access to VPC endpoints over HTTPS.
  *
- * @param {Object} params
  * @return {Object}
  */
 function buildVPCEndpointSecurityGroup() {

--- a/src/vpce.js
+++ b/src/vpce.js
@@ -44,7 +44,7 @@ function buildVPCEndpoint(service, { routeTableIds = [], subnetIds = [] } = {}) 
     endpoint.Properties.PrivateDnsEnabled = true;
     endpoint.Properties.SecurityGroupIds = [
       {
-        Ref: 'EndpointSecurityGroup',
+        Ref: 'AppSecurityGroup',
       },
     ];
   }
@@ -88,47 +88,7 @@ function buildEndpointServices(services = [], numZones = 0) {
   return resources;
 }
 
-/**
- * Build a SecurityGroup to allow the access to VPC endpoints over HTTPS.
- *
- * @return {Object}
- */
-function buildVPCEndpointSecurityGroup() {
-  return {
-    EndpointSecurityGroup: {
-      Type: 'AWS::EC2::SecurityGroup',
-      Properties: {
-        GroupDescription: 'VPC Endpoint Security Group',
-        VpcId: {
-          Ref: 'VPC',
-        },
-        SecurityGroupIngress: [
-          {
-            SourceSecurityGroupId: {
-              Ref: 'AppSecurityGroup',
-            },
-            Description: 'Allow inbound HTTPS traffic from AppSecurityGroup',
-            IpProtocol: 'tcp',
-            FromPort: 443,
-            ToPort: 443,
-          },
-        ],
-        Tags: [
-          {
-            Key: 'Name',
-            Value: {
-              // eslint-disable-next-line no-template-curly-in-string
-              'Fn::Sub': '${AWS::StackName}-vpce',
-            },
-          },
-        ],
-      },
-    },
-  };
-}
-
 module.exports = {
   buildEndpointServices,
   buildVPCEndpoint,
-  buildVPCEndpointSecurityGroup,
 };


### PR DESCRIPTION
### BREAKING CHANGES

- Renamed `LambdaExecutionSecurityGroup` to `AppSecurityGroup`
- The `AppSecurityGroup` only allows HTTPS ingress and egress
  - If an S3 VPC Endpoint is created, `AppSecurityGroup` also allows HTTP egress just to S3
- The VPC default security group's egress rule is modified to only permit outbound access to itself (see [Remove Default Rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#aws-properties-ec2-security-group--examples--Remove_Default_Rule))
- Removed the `LambdaEndpointSecurityGroup` security group in favor of using the `AppSecurityGroup` for VPC Interface Endpoints

### NEW FEATURES

- Ability to create SSM parameters by specifying `createParameters: true` in the `custom.vpcConfig` options
- A `DHCPOptionsSet` is now created and attached to the VPC

### OTHER CHANGES

- Replaced usages of `Fn::Join` with `Fn::Sub` to make the generated CloudFormation template more readable