### PR TITLE
Add custom outbound TCP ports to the security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ custom:
 
     # Optionally specify additional outbound TCP ports to the internet.
     # For instance to connect to external databases, like mysql on port 3306 or mongodb on 27017  
-    outboundTcpPorts: [27017, 3306]
+    outboundTcpPorts: 
+      - 27017
+      - 3306
 ```
 
 ## CloudFormation Outputs

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ If your Lambda functions need to [access the internet](https://docs.aws.amazon.c
 
 By default, `AWS::EC2::VPCEndpoint` "Gateway" endpoints for S3 and DynamoDB will be provisioned within each availability zone to provide internal access to these services (there is no additional charge for using Gateway Type VPC endpoints). You can selectively control which `AWS::EC2::VPCEndpoint` "Interface" endpoints are available within your VPC using the `services` configuration option below. Not all AWS services are available in every region, so the plugin will query AWS to validate the services you have selected and notify you if any changes are required (there is an additional charge for using Interface Type VPC endpoints).
 
+In case you want open additional ports to the internet when using external databases and other services, you can use the `outboundTcpPorts` configuration option to specify these ports.
+
 If you specify more then one availability zone, this plugin will also provision the following database-related resources (controlled using the `subnetGroups` plugin option):
 
 - `AWS::RDS::DBSubnetGroup`
@@ -123,6 +125,10 @@ custom:
 
     # Whether to export stack outputs so it may be consumed by other stacks
     exportOutputs: false
+
+    # Optionally specify additional outbound TCP ports to the internet.
+    # For instance to connect to external databases, like mysql on port 3306 or mongodb on 27017  
+    outboundTcpPorts: [27017, 3306]
 ```
 
 ## CloudFormation Outputs

--- a/__tests__/vpc.test.js
+++ b/__tests__/vpc.test.js
@@ -184,6 +184,74 @@ describe('vpc', () => {
     });
   });
 
+  describe('#buildAppSecurityGroupOutboundTcpPorts', () => {
+    it('builds a security group with custom outbound tcp ports', () => {
+      const expected = {
+        DefaultSecurityGroupEgress: {
+          Type: 'AWS::EC2::SecurityGroupEgress',
+          Properties: {
+            IpProtocol: '-1',
+            DestinationSecurityGroupId: {
+              'Fn::GetAtt': ['VPC', 'DefaultSecurityGroup'],
+            },
+            GroupId: {
+              'Fn::GetAtt': ['VPC', 'DefaultSecurityGroup'],
+            },
+          },
+        },
+        AppSecurityGroup: {
+          Type: 'AWS::EC2::SecurityGroup',
+          Properties: {
+            GroupDescription: 'Application Security Group',
+            SecurityGroupEgress: [
+              {
+                Description: 'permit HTTPS outbound',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+                CidrIp: '0.0.0.0/0',
+              },
+              {
+                Description: 'permit port 8080',
+                IpProtocol: 'tcp',
+                FromPort: 8080,
+                ToPort: 8080,
+                CidrIp: '0.0.0.0/0',
+              },
+            ],
+            SecurityGroupIngress: [
+              {
+                Description: 'permit HTTPS inbound',
+                IpProtocol: 'tcp',
+                FromPort: 443,
+                ToPort: 443,
+                CidrIp: '0.0.0.0/0',
+              },
+            ],
+            VpcId: {
+              Ref: 'VPC',
+            },
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-sg',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      const prefixLists = null;
+      const outboundTcpPorts = [8080];
+      const actual = buildAppSecurityGroup(prefixLists, outboundTcpPorts);
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
   describe('#buildDHCPOptions', () => {
     it('builds a DHCP option set in us-east-1', () => {
       const expected = {

--- a/__tests__/vpc.test.js
+++ b/__tests__/vpc.test.js
@@ -212,7 +212,7 @@ describe('vpc', () => {
                 CidrIp: '0.0.0.0/0',
               },
               {
-                Description: 'permit port 8080',
+                Description: 'permit port 8080 to the internet',
                 IpProtocol: 'tcp',
                 FromPort: 8080,
                 ToPort: 8080,

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ class ServerlessVpcPlugin {
     let bastionHostKeyName = null;
     let exportOutputs = false;
     let subnetGroups = VALID_SUBNET_GROUPS;
+    let outboundTcpPorts = [];
 
     const { vpcConfig } = this.serverless.service.custom;
 
@@ -112,6 +113,10 @@ class ServerlessVpcPlugin {
 
       if ('createParameters' in vpcConfig && typeof vpcConfig.createParameters === 'boolean') {
         ({ createParameters } = vpcConfig);
+      }
+
+      if (Array.isArray(vpcConfig.outboundTcpPorts)) {
+        outboundTcpPorts = vpcConfig.outboundTcpPorts;
       }
     }
 
@@ -181,7 +186,7 @@ class ServerlessVpcPlugin {
         createDbSubnet,
         createNatInstance: !!(createNatInstance && vpcNatAmi),
       }),
-      buildAppSecurityGroup(prefixLists),
+      buildAppSecurityGroup(prefixLists, outboundTcpPorts),
       buildDHCPOptions(region),
     );
 

--- a/src/vpc.js
+++ b/src/vpc.js
@@ -109,7 +109,7 @@ function buildAppSecurityGroup(prefixLists = null, outboundTcpPorts = []) {
 
   outboundTcpPorts.forEach((port) => {
     egress.push({
-      Description: `permit port ${port}`,
+      Description: `permit port ${port} to the internet`,
       IpProtocol: 'tcp',
       FromPort: port,
       ToPort: port,

--- a/src/vpc.js
+++ b/src/vpc.js
@@ -70,9 +70,10 @@ function buildInternetGateway() {
  * Build a SecurityGroup to be used by applications
  *
  * @param {Object} prefixLists AWS-owned managed prefix lists in the region
+ * @param {Array} outboundTcpPorts Additional TCP ports for outbound connections
  * @return {Object}
  */
-function buildAppSecurityGroup(prefixLists = null) {
+function buildAppSecurityGroup(prefixLists = null, outboundTcpPorts = []) {
   const egress = [
     {
       Description: 'permit HTTPS outbound',
@@ -105,6 +106,16 @@ function buildAppSecurityGroup(prefixLists = null) {
       ToPort: 443,
     });
   }
+
+  outboundTcpPorts.forEach((port) => {
+    egress.push({
+      Description: `permit port ${port}`,
+      IpProtocol: 'tcp',
+      FromPort: port,
+      ToPort: port,
+      CidrIp: '0.0.0.0/0',
+    });
+  });
 
   return {
     DefaultSecurityGroupEgress: {


### PR DESCRIPTION
Our project needs access to an external databaseserver which is not accessible by default from the VPC generated with this plugin. So we added the following changes to make this possible and wanted to share it 😄 