### PR TITLE
Add 'enabled' configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ provider:
 
 custom:
   vpcConfig:
+    # Whether plugin is enabled. Can be used to selectively disable plugin
+    # on certain stages or configurations. Defaults to true.
+    enabled: true
+
     cidrBlock: '10.0.0.0/16'
 
     # if createNatGateway is a boolean "true", a NAT Gateway and EIP will be provisioned in each zone

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,11 @@ class ServerlessVpcPlugin {
     const { vpcConfig } = this.serverless.service.custom;
 
     if (vpcConfig) {
+      if (vpcConfig.enabled === false) {
+        this.serverless.cli.log('VPC plugin disabled');
+        return;
+      }
+
       if (vpcConfig.cidrBlock && typeof vpcConfig.cidrBlock === 'string') {
         ({ cidrBlock } = vpcConfig);
       }


### PR DESCRIPTION
Add a new configuration flag, enabled, which can be used to
effectively disable the plugin. This flag allows us to control
whether plugin is active based on serverless variables, such
as stage. i.e.

```yml
provider:
  stage: ${opt:stage, 'dev'}

custom:
  staged: ${self:custom.stageVars.${self:provider.stage}}

  stageVars:
    dev:
      vpc_enabled: false

  vpcConfig:
    enabled: ${self:custom.staged.vpc_enabled, true}
```