### PR TITLE
Fixed Fn::GetAtt CF error

### DIFF
--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -47,6 +47,8 @@ custom:
       - elasticfilesystem
     subnetGroups:
       - rds
+#    createBastionHost: true
+#    bastionHostKeyName: bastion-key
   webpack:
     includeModules:
       forceExclude:
@@ -59,7 +61,7 @@ functions:
     fileSystemConfig:
       localMountPath: /mnt/efs0
       arn:
-        "Fn::GetAtt": "EFSAccessPoint.Arn"
+        'Fn::GetAtt': [ EFSAccessPoint, Arn ]
     description: Example Handler
     dependsOn:
       - EFSMountTarget1


### PR DESCRIPTION
As per https://github.com/smoketurner/serverless-vpc-plugin/issues/695, I pulled down the repo and tried to run `sls deploy` on the example directory but it fails out of the box right now due to an error on line 62 of `serverless.yml`:


> The CloudFormation template is invalid: Template error: every Fn::GetAtt object requires two non-empty parameters, the resource name and the resource attribute

This corrects the line.

This was run on my environment:

```
  Your Environment Information ---------------------------
     Operating System:          darwin
     Node Version:              14.4.0
     Framework Version:         2.54.0 (local)
     Plugin Version:            5.4.3
     SDK Version:               4.2.6
     Components Version:        3.15.1
```