### PR TITLE
Added IncludeDeprecated to the describeImages call 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -410,6 +410,7 @@ class ServerlessVpcPlugin {
           Values: ['hvm'],
         },
       ],
+      IncludeDeprecated: true,
     };
     const data = await this.provider.request('EC2', 'describeImages', params);
     return data.Images.sort((a, b) => {


### PR DESCRIPTION
because the used images are default hidden in the call.

AWS hides the images after 2 years.