### PR TITLE
Update searched NAT AMI name prefix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ class ServerlessVpcPlugin {
     if (createNatInstance) {
       this.serverless.cli.log('Finding latest VPC NAT Instance AMI...');
 
-      const images = await this.getImagesByName('amzn-ami-vpc-nat-hvm*');
+      const images = await this.getImagesByName('amzn-ami-vpc-nat*');
       if (Array.isArray(images) && images.length > 0) {
         [vpcNatAmi] = images;
       } else {


### PR DESCRIPTION
It looks like Amazon has changed the naming convention of the NAT AMI
images they maintain. It no longer includes the virtualization type.
Example:
old name: "amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs"
new name: "amzn-ami-vpc-nat-2018.03.0.20220705.1-x86_64-ebs"

This patch changes the name prefix that is used to find a suitable AMI
image, when creating NAT instances to exclude the virtualization type.
Since the virtualization type is specified in another filter, this
should not loosen the restrictions.

Fixes: #993 