### PR TITLE
Fix tests

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -16,7 +16,8 @@ describe('ServerlessVpcPlugin', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless(options);
+    const config = { commands: [], options: options };
+    serverless = new Serverless(config);
     serverless.cli = new serverless.classes.CLI();
 
     const provider = new AwsProvider(serverless, options);

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -8,6 +8,12 @@ const ServerlessVpcPlugin = require('../src/index');
 describe('ServerlessVpcPlugin', () => {
   let serverless;
   let plugin;
+  let mockedMethods = [];
+
+  function mockHelper(serviceName, methodName, callback) {
+    AWS.mock(serviceName, methodName, callback);
+    mockedMethods.push([serviceName, methodName]);
+  }
 
   beforeEach(() => {
     nock.disableNetConnect();
@@ -41,7 +47,10 @@ describe('ServerlessVpcPlugin', () => {
   });
 
   afterEach(() => {
-    AWS.restore();
+    while (mockedMethods.length > 0) {
+      const [serviceName, methodName] = mockedMethods.pop();
+      AWS.restore(serviceName, methodName);
+    }
   });
 
   describe('#constructor', () => {
@@ -133,7 +142,7 @@ describe('ServerlessVpcPlugin', () => {
         return callback(null, response);
       });
 
-      AWS.mock('EC2', 'describeAvailabilityZones', mockCallback);
+      mockHelper('EC2', 'describeAvailabilityZones', mockCallback);
 
       serverless.service.custom.vpcConfig = {
         services: [],
@@ -178,7 +187,7 @@ describe('ServerlessVpcPlugin', () => {
         return callback(null, response);
       });
 
-      AWS.mock('EC2', 'describeAvailabilityZones', mockCallback);
+      mockHelper('EC2', 'describeAvailabilityZones', mockCallback);
 
       const actual = await plugin.getZonesPerRegion('us-east-1');
 
@@ -204,7 +213,7 @@ describe('ServerlessVpcPlugin', () => {
         return callback(null, response);
       });
 
-      AWS.mock('EC2', 'describeVpcEndpointServices', mockCallback);
+      mockHelper('EC2', 'describeVpcEndpointServices', mockCallback);
 
       const actual = await plugin.getVpcEndpointServicesPerRegion('us-east-1');
 
@@ -236,7 +245,7 @@ describe('ServerlessVpcPlugin', () => {
         return callback(null, response);
       });
 
-      AWS.mock('EC2', 'describeImages', mockCallback);
+      mockHelper('EC2', 'describeImages', mockCallback);
 
       const actual = await plugin.getImagesByName('test');
       expect(actual).toEqual(['ami-test']);
@@ -259,7 +268,7 @@ describe('ServerlessVpcPlugin', () => {
         return callback(null, response);
       });
 
-      AWS.mock('EC2', 'describeVpcEndpointServices', mockCallback);
+      mockHelper('EC2', 'describeVpcEndpointServices', mockCallback);
 
       const actual = await plugin.validateServices('us-east-1', ['blah']);
       expect(actual).toEqual(['com.amazonaws.us-east-1.blah']);
@@ -296,7 +305,7 @@ describe('ServerlessVpcPlugin', () => {
         return callback(null, response);
       });
 
-      AWS.mock('EC2', 'describeManagedPrefixLists', mockCallback);
+      mockHelper('EC2', 'describeManagedPrefixLists', mockCallback);
 
       const expected = {
         s3: 'pl-63a5400a',


### PR DESCRIPTION
Hello,

This PR includes changes to fix the test suite.

There were two problems with the tests:
1. The `Serverless` object's constructor was not called as expected.
    Serverless v3.0.0 introduced this breaking change for the `Serverless` object.
    Excerpt from release notes: "Error instead of warning when missing commands or options".
    Release notes: https://github.com/serverless/serverless/releases/tag/v3.0.0
    Commit: https://github.com/serverless/serverless/pull/10158/commits/9488c466d7704334dad3c3c01285061859219836#
2. The test suite was "restoring" too much of the 'aws-sdk-mock' mocks.
    When mocking an 'aws-sdk' method, 'aws-sdk-mock' would first create a
    mock for the service itself and then one for the method.
    When restoring everything, 'aws-sdk-mock' would first restore all
    mocked methods of a service and then the service mock.

    For some reason it is not possible to mock the service a second time and
    by extension mock a method from it.

    Calling 'restore' with both service name and method name restores only
    the mocked method and not the service. This allows the service mock to
    be reused and by extension another method to be mocked.

To solve the second problem I've added a way to remember what methods were mocked, so that only they can be cleaned-up after the test execution is complete. To help correctly remembering what is mocked I've added a helper, to replace the 'AWS.mock` method.
I've decided to go with the remembering approach, so that a failing test would not affect the ones executed after it.