### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,5 @@ As an example, if the stack name you want to reference is `new-service-dev`, you
 vpc:
   securityGroupIds:
     - ${ssm:/SLS/new-service-dev/AppSecurityGroup}
-  subnetIds: ${ssm:/SLS/new-service-dev/AppSubnets~split}
+  subnetIds: ${ssm:/SLS/new-service-dev/AppSubnets} # sls will split this comma delimited list automatically because it's a StringList parameter type
 ```
-
-(Note the usage of `~split` to split the SSM `StringList` parameter type and return an array of values)


### PR DESCRIPTION
This PR fixes some outdated advice in the README. It's a simple fix and improvement

I was getting this error:

> Cannot resolve serverless.yml: Variables resolution errored with:
>   - Cannot resolve variable at "provider.vpc.subnetIds": Parameter name: can't be prefixed with "ssm" (case-insensitive). If formed as a path, it can consist of sub-paths divided by slash symbol; each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_

After researching, it turns out that the `~split` feature is dead in V3 release of serverless-framework, see comment here: https://github.com/serverless/serverless/pull/6365#issuecomment-1104914038. sls will now automatically split the list for you.