### PR TITLE
Provide option for using non-deprecated amazon instances with fck-nat

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ custom:
 
     # Whether to create a NAT instance
     createNatInstance: false
+    # When enabled with the above, it will utilize the
+    # [fck-nat](https://fck-nat.dev/) AMI vs. the Amazon AMI's with arm64
+    # t4g.nano instances
+    createNatInstanceFckNat: false
 
     # Whether to create AWS Systems Manager (SSM) Parameters
     createParameters: false

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -247,7 +247,7 @@ describe('ServerlessVpcPlugin', () => {
 
       mockHelper('EC2', 'describeImages', mockCallback);
 
-      const actual = await plugin.getImagesByName('test');
+      const actual = await plugin.getImagesByName('test', 'test', 'test');
       expect(actual).toEqual(['ami-test']);
       expect(mockCallback).toHaveBeenCalled();
       expect.assertions(3);

--- a/__tests__/nat_instance.test.js
+++ b/__tests__/nat_instance.test.js
@@ -121,7 +121,68 @@ describe('nat_instance', () => {
 
       const imageId = 'ami-00a9d4a05375b2763';
 
-      const actual = buildNatInstance(imageId, ['us-east-1a', 'us-east-1b']);
+      const actual = buildNatInstance(imageId, 't2.micro', ['us-east-1a', 'us-east-1b']);
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
+  describe('#buildNatInstance createNatInstanceFckNat', () => {
+    it('builds an EC2 instance', () => {
+      const expected = {
+        NatInstance: {
+          Type: 'AWS::EC2::Instance',
+          DependsOn: 'InternetGatewayAttachment',
+          Properties: {
+            AvailabilityZone: {
+              'Fn::Select': ['0', ['us-east-1a', 'us-east-1b']],
+            },
+            BlockDeviceMappings: [
+              {
+                DeviceName: '/dev/xvda',
+                Ebs: {
+                  VolumeSize: 10,
+                  VolumeType: 'gp2',
+                  DeleteOnTermination: true,
+                },
+              },
+            ],
+            ImageId: 'ami-0d30a34832b46dcae',
+            InstanceType: 't4g.nano',
+            Monitoring: false,
+            NetworkInterfaces: [
+              {
+                AssociatePublicIpAddress: true,
+                DeleteOnTermination: true,
+                Description: 'eth0',
+                DeviceIndex: '0',
+                GroupSet: [
+                  {
+                    Ref: 'NatSecurityGroup',
+                  },
+                ],
+                SubnetId: {
+                  Ref: 'PublicSubnet1',
+                },
+              },
+            ],
+            SourceDestCheck: false,
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-nat',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      const imageId = 'ami-0d30a34832b46dcae';
+
+      const actual = buildNatInstance(imageId, 't4g.nano', ['us-east-1a', 'us-east-1b']);
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,16 @@
       },
       "devDependencies": {
         "aws-sdk-mock": "5.8.0",
-        "eslint": "8.51.0",
+        "eslint": "^8.51.0",
         "eslint-config-airbnb-base": "15.0.0",
-        "eslint-config-prettier": "8.8.0",
-        "eslint-plugin-import": "2.27.5",
-        "eslint-plugin-jest": "27.2.3",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-prettier": "5.0.1",
-        "jest": "29.6.2",
-        "nock": "13.3.4",
-        "prettier": "3.0.1",
-        "serverless": "3.34.0"
+        "jest": "^29.6.2",
+        "nock": "^13.3.4",
+        "prettier": "^3.0.1",
+        "serverless": "^3.34.0"
       },
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -30,15 +30,15 @@
   },
   "devDependencies": {
     "aws-sdk-mock": "5.8.0",
-    "eslint": "8.51.0",
+    "eslint": "^8.51.0",
     "eslint-config-airbnb-base": "15.0.0",
-    "eslint-config-prettier": "8.8.0",
-    "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-jest": "27.2.3",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-prettier": "5.0.1",
-    "jest": "29.6.2",
-    "nock": "13.3.4",
-    "prettier": "3.0.1",
-    "serverless": "3.34.0"
+    "jest": "^29.6.2",
+    "nock": "^13.3.4",
+    "prettier": "^3.0.1",
+    "serverless": "^3.34.0"
   }
 }

--- a/src/nat_instance.js
+++ b/src/nat_instance.js
@@ -68,11 +68,12 @@ function buildNatSecurityGroup() {
  * Build the NAT instance
  *
  * @param {Object} imageId AMI image ID
+ * @param {String} instance type
  * @param {Array} zones Array of availability zones
  * @param {Object} params
  * @return {Object}
  */
-function buildNatInstance(imageId, zones = [], { name = 'NatInstance' } = {}) {
+function buildNatInstance(imageId, instanceType, zones = [], { name = 'NatInstance' } = {}) {
   if (!imageId) {
     return {};
   }
@@ -99,7 +100,7 @@ function buildNatInstance(imageId, zones = [], { name = 'NatInstance' } = {}) {
           },
         ],
         ImageId: imageId, // amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs
-        InstanceType: 't2.micro',
+        InstanceType: instanceType,
         Monitoring: false,
         NetworkInterfaces: [
           {


### PR DESCRIPTION
[fck-nat](https://fck-nat.dev/) provides the same behavior as the amazon nat instances, with the exception that it is up to date and can be run on the arm64 platforms thus reducing overall cost. since several people already have the existing deployed, it makes more sense to provide an option to allow them to use it.

When using `createNatInstance = true` AND `createNatInstanceFckNat = true`, this will then utilize the FckNat instances rather than the deprecated amazon instances.